### PR TITLE
ci: Fix: use full path for the reusable actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,20 +20,20 @@ jobs:
 
       - name: Sync codebase
         id: sync
-        uses: ./.github/actions/sync
+        uses: qualcomm-linux/kernel-config/.github/actions/sync@main
         with:
           base_branch: ${{ github.base_ref }}
           pr_number: ${{ github.event.pull_request.number }}
 
       - name: Pull docker image
-        uses: ./.github/actions/pull_docker_image
+        uses: qualcomm-linux/kernel-config/.github/actions/pull_docker_image@main
         with:
           image: ${{ inputs.docker_image }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build workspace
         id: build_workspace
-        uses: ./.github/actions/build
+        uses: qualcomm-linux/kernel-config/.github/actions/build@main
         with:
           docker_image: ${{ inputs.docker_image }}
           workspace_path: ${{ steps.sync.outputs.workspace_path }}
@@ -49,7 +49,7 @@ jobs:
           echo "../kobj/arch/arm64/boot/dts/qcom/qcs6490-rb3gen2.dtb" >> ../artifacts/file_list.txt
 
       - name: Upload artifacts
-        uses: ./.github/actions/aws_s3_helper
+        uses: qualcomm-linux/kernel-config/.github/actions/aws_s3_helper@main
         with:
           s3_bucket: qli-prd-kernel-gh-artifacts
           local_file: ${{ steps.sync.outputs.workspace_path }}/../artifacts/file_list.txt

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
           fetch-depth: 0
 
       - name: Pull docker image
-        uses: ./.github/actions/pull_docker_image
+        uses: qualcomm-linux/kernel-config/.github/actions/pull_docker_image@main
         with:
           image: ${{ inputs.docker_image }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -38,7 +38,7 @@ jobs:
         run: cd .. && git clone https://github.com/qualcomm-linux/job_render
 
       - name: Create lava job definition
-        uses: ./.github/actions/lava_job_render
+        uses: qualcomm-linux/kernel-config/.github/actions/lava_job_render@main
         id: create_job_definition
         with:
           docker_image: ${{ inputs.docker_image }}
@@ -96,3 +96,4 @@ jobs:
           </details>
           '
           echo -e "$SUMMARY" >> $GITHUB_STEP_SUMMARY
+


### PR DESCRIPTION
Use full path for the reusable actions to be able
to pick from kernel-config workflows