### PR TITLE
ci: Fix: update modules.tar.xz file path

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,19 +39,22 @@ jobs:
 
       - name: Create file list for artifacts upload
         run: |
-          cd ${{ steps.sync.outputs.workspace_path }}
-          touch ${{ github.workspace }}/artifacts/file_list.txt
-          tar -cJf ${{ github.workspace }}/modules.tar.xz ../kobj/tar-install/lib/modules/
-          echo "${{ github.workspace }}/modules.tar.xz" >> ${{ github.workspace }}/artifacts/file_list.txt
-          echo "${{ steps.sync.outputs.workspace_path }}/../kobj/arch/arm64/boot/Image" >> ${{ github.workspace }}/artifacts/file_list.txt
-          echo "${{ steps.sync.outputs.workspace_path }}/../kobj/vmlinux" >> ${{ github.workspace }}/artifacts/file_list.txt
-          echo "${{ steps.sync.outputs.workspace_path }}/../kobj/arch/arm64/boot/dts/qcom/qcs6490-rb3gen2.dtb" >> ${{ github.workspace }}/artifacts/file_list.txt
+          workspace=${{ steps.sync.outputs.workspace_path }}
+          touch $workspace/../artifacts/file_list.txt
+          cd $workspace/../kobj/tar-install
+          tar -cJf ${{ github.workspace }}/modules.tar.xz lib/modules/
+          
+          echo "${{ github.workspace }}/modules.tar.xz" >> $workspace/../artifacts/file_list.txt
+          echo "$workspace/../kobj/arch/arm64/boot/Image" >> $workspace/../artifacts/file_list.txt
+          echo "$workspace/../kobj/vmlinux" >> $workspace/../artifacts/file_list.txt
+          echo "$workspace/../kobj/arch/arm64/boot/dts/qcom/qcs6490-rb3gen2.dtb" >> $workspace/../artifacts/file_list.txt
+
 
       - name: Upload artifacts
         uses: qualcomm-linux/kernel-config/.github/actions/aws_s3_helper@main
         with:
           s3_bucket: qli-prd-kernel-gh-artifacts
-          local_file: ${{ github.workspace }}/artifacts/file_list.txt
+          local_file: ${{ steps.sync.outputs.workspace_path }}/../artifacts/file_list.txt
           mode: multi-upload
 
       - name: Clean up


### PR DESCRIPTION
modules.tar.xz should be generated from inside tar-install path.
Changing directory before generating the tar.