### PR TITLE
Enable LAVA test support for multiple targets via matrix strategy

### DIFF
--- a/.github/actions/aws_s3_helper/action.yml
+++ b/.github/actions/aws_s3_helper/action.yml
@@ -13,6 +13,10 @@ inputs:
     description: Download file paths
     required: false
     default: ''
+  download_location:
+    description: file download location
+    required: false
+    default: .
   mode:
     description: Mode of operation (upload/download)
     required: true
@@ -73,7 +77,7 @@ runs:
           download)
             #Download The required file from s3
             echo "Downloading files from S3 bucket..."
-            aws s3 sync s3://${{ inputs.s3_bucket }}/${{ inputs.download_file }} .
+            aws s3 cp s3://${{ inputs.s3_bucket }}/${{ inputs.download_file }} ${{ inputs.download_location }}
             ;;
           *)
             echo "Invalid mode. Use 'upload' or 'download'."

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -41,4 +41,3 @@ runs:
       run: |
         cd ${{ inputs.workspace_path }}
         (cd ../kobj/tar-install ; find lib/modules | cpio -o -H newc -R +0:+0 | gzip -9 >> ../../artifacts/ramdisk.gz)
-

--- a/.github/actions/lava_job_render/action.yml
+++ b/.github/actions/lava_job_render/action.yml
@@ -3,7 +3,7 @@ inputs:
   docker_image:
     description: Docker image
     required: true
-    default: kmake-image:latest
+    default: kmake-image:ver.1.0
 
 runs:
   using: "composite"
@@ -37,7 +37,8 @@ runs:
           const modulesTarUrl = findUrlByFilename('modules.tar.xz');
           const imageUrl = findUrlByFilename('Image');
           const vmlinuxUrl = findUrlByFilename('vmlinux');
-          const dtbUrl = findUrlByFilename('qcs6490-rb3gen2.dtb');
+          const dtbFilename = `${process.env.MACHINE}.dtb`;
+          const dtbUrl = findUrlByFilename(dtbFilename);
           // Set outputs
           core.setOutput('modules_url', modulesTarUrl);
           core.setOutput('image_url', imageUrl);
@@ -61,7 +62,7 @@ runs:
           -v "$(dirname "$PWD")":"$(dirname "$PWD")" \
           -e dtb_url="${{ steps.process_urls.outputs.dtb_url }}" \
           ${{ inputs.docker_image }} \
-          jq '.artifacts["dtbs/qcom/qcs6490-rb3gen2.dtb"] = env.dtb_url' data/metadata.json > temp.json && mv temp.json data/metadata.json
+          jq '.artifacts["dtbs/qcom/${{ env.MACHINE }}.dtb"] = env.dtb_url' data/metadata.json > temp.json && mv temp.json data/metadata.json
 
     - name: Upload metadata.json
       id: upload_metadata
@@ -119,7 +120,7 @@ runs:
       run: |
         cd ../job_render
         ramdisk_url="$(aws s3 presign s3://qli-prd-kernel-gh-artifacts/meta-qcom/initramfs-kerneltest-full-image-qcom-armv8a.cpio.gz --expires 7600)"
-        firmware_url="$(aws s3 presign s3://qli-prd-kernel-gh-artifacts/meta-qcom/initramfs-firmware-rb3gen2-image-qcom-armv8a.cpio.gz --expires 7600)"
+        firmware_url="$(aws s3 presign s3://qli-prd-kernel-gh-artifacts/meta-qcom/initramfs-firmware-${{ env.FIRMWARE }}-image-qcom-armv8a.cpio.gz --expires 7600)"
         # using ramdisk_url
         docker run -i --rm \
           --user "$(id -u):$(id -g)" \
@@ -142,13 +143,16 @@ runs:
       shell: bash
       run: |
         cd ../job_render
-        mkdir renders
+        mkdir -p renders
+
         docker run -i --rm \
           --user "$(id -u):$(id -g)" \
           --workdir="$PWD" \
           -v "$(dirname "$PWD")":"$(dirname "$PWD")" \
+          -e TARGET="${{ env.LAVA_NAME }}" \
+          -e TARGET_DTB="${{ env.MACHINE }}" \
           ${{ inputs.docker_image }} \
           sh -c 'export BOOT_METHOD=fastboot && \
-            export TARGET=qcs6490 && \
-            export TARGET_DTB=qcs6490-rb3gen2 && \
+            export TARGET=${TARGET} && \
+            export TARGET_DTB=${TARGET_DTB} && \
             python3 lava_Job_definition_generator.py --localjson ./data/cloudData.json --qcom-next-ci-premerge'

--- a/.github/actions/loading/action.yml
+++ b/.github/actions/loading/action.yml
@@ -1,0 +1,48 @@
+---
+name: Load Parameters
+description: Load parameters for the build job
+
+outputs:
+  build_matrix:
+    description: Build matrix
+    value: ${{ steps.set-matrix.outputs.build_matrix }}
+
+  full_matrix:
+    description: full matrix containing lava devails
+    value: ${{ steps.set-matrix.outputs.full_matrix }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Set Build Matrix
+      id: set-matrix
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const fs = require('fs');
+          const path = require('path');
+          const filePath = path.join(process.env.GITHUB_WORKSPACE, 'ci', 'MACHINES.json');
+          let file;
+          try {
+            if (!fs.existsSync(filePath)) {
+              core.setFailed(`MACHINES.json not found at ${filePath}`);
+              return;
+            }
+            file = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+          } catch (err) {
+            core.setFailed(`Failed to load or parse MACHINES.json: ${err.message}`);
+            return;
+          }
+          // Slim matrix for better job visibility
+          const slim_matrix = Object.entries(file).map(([machine, [firmware]]) => ({ machine, firmware }));
+          core.setOutput('build_matrix', JSON.stringify(slim_matrix));
+          console.log(slim_matrix);
+
+          // Full matrix to pass to test jobs
+          const complete_matrix = Object.entries(file).map(([machine, [firmware, lavaname]]) => ({
+            machine,
+            firmware,
+            lavaname
+          }));
+          core.setOutput('full_matrix', JSON.stringify(complete_matrix));
+          console.log(complete_matrix);

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,11 @@ on:
         type: string
         required: true
 
+      build_matrix:
+        description: Build matrix for multi target builds
+        type: string
+        required: true
+
 jobs:
   build:
     runs-on:
@@ -47,8 +52,12 @@ jobs:
           echo "${{ github.workspace }}/modules.tar.xz" >> $workspace/../artifacts/file_list.txt
           echo "$workspace/../kobj/arch/arm64/boot/Image" >> $workspace/../artifacts/file_list.txt
           echo "$workspace/../kobj/vmlinux" >> $workspace/../artifacts/file_list.txt
-          echo "$workspace/../kobj/arch/arm64/boot/dts/qcom/qcs6490-rb3gen2.dtb" >> $workspace/../artifacts/file_list.txt
 
+          # Loop through all machines from the build_matrix input
+          machines='${{ inputs.build_matrix }}'
+          for machine in $(echo "$machines" | jq -r '.[].machine'); do
+            echo "$workspace/../kobj/arch/arm64/boot/dts/qcom/${machine}.dtb" >> $workspace/../artifacts/file_list.txt
+          done
 
       - name: Upload artifacts
         uses: qualcomm-linux/kernel-config/.github/actions/aws_s3_helper@main

--- a/.github/workflows/loading.yml
+++ b/.github/workflows/loading.yml
@@ -1,0 +1,30 @@
+---
+name: _loading
+description: Load required parameters for the subsequent jobs
+
+on:
+  workflow_call:
+    outputs:
+      build_matrix:
+        description: Build matrix
+        value: ${{ jobs.loading.outputs.build_matrix }}
+
+      full_matrix:
+        description: Full Matrix containing lava description
+        value: ${{ jobs.loading.outputs.full_matrix }}
+
+jobs:
+  loading:
+    runs-on: ubuntu-latest
+    outputs:
+      build_matrix: ${{ steps.loading.outputs.build_matrix }}
+      full_matrix: ${{ steps.loading.outputs.full_matrix }}
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+        with:
+          repository: qualcomm-linux/kernel-config
+
+      - name: Load Parameters
+        id: loading
+        uses: qualcomm-linux/kernel-config/.github/actions/loading@main

--- a/.github/workflows/pre_merge.yml
+++ b/.github/workflows/pre_merge.yml
@@ -3,15 +3,23 @@ on:
   workflow_call:
 
 jobs:
+  loading:
+    uses: ./.github/workflows/loading.yml
+    secrets: inherit
+
   build:
+    needs: loading
     uses: ./.github/workflows/build.yml
     secrets: inherit
     with:
       docker_image: kmake-image:ver.1.0
+      build_matrix: ${{ needs.loading.outputs.build_matrix }}
 
   test:
-    needs: [build]
+    needs: [loading, build]
     uses: ./.github/workflows/test.yml
     secrets: inherit
     with:
       docker_image: kmake-image:ver.1.0
+      build_matrix: ${{ needs.loading.outputs.build_matrix }}
+      full_matrix: ${{ needs.loading.outputs.full_matrix }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,13 +8,28 @@ on:
         description: Docker image
         type: string
         required: true
-        default: kmake-image:latest
+        default: kmake-image:ver.1.0
+
+      build_matrix:
+        description: Build matrix for multi target builds
+        type: string
+        required: true
+
+      full_matrix:
+        description: Full matrix containing lava description
+        type: string
+        required: true
+
 
 jobs:
   test:
     runs-on:
       group: GHA-Kernel-SelfHosted-RG
       labels: [ self-hosted, kernel-prd-u2404-x64-large-od-ephem ]
+    strategy:
+      fail-fast: false
+      matrix:
+        build_matrix: ${{ fromJson(inputs.build_matrix) }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -31,22 +46,45 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: presigned_urls.json
+          merge-multiple: true
           path: ${{ github.workspace }}
 
       - name: Clone lava job render scripts
         run: cd .. && git clone https://github.com/qualcomm-linux/job_render
+
+      - name: Extract the LAVA machine name
+        id: get_lavaname
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fullMatrix = JSON.parse(`${{ inputs.full_matrix }}`);
+            const currentMachine = `${{ matrix.build_matrix.machine }}`;
+
+            const entry = fullMatrix.find(item => item.machine === currentMachine);
+            if (!entry) {
+              core.setFailed(`No entry found in full matrix for machine: ${currentMachine}`);
+              return;
+            }
+
+            const lavaname = entry.lavaname;
+            console.log(`Lavaname for ${currentMachine} is ${lavaname}`);
+            core.setOutput("LAVANAME", lavaname);
 
       - name: Create lava job definition
         uses: qualcomm-linux/kernel-config/.github/actions/lava_job_render@main
         id: create_job_definition
         with:
           docker_image: ${{ inputs.docker_image }}
+        env:
+          FIRMWARE: ${{ matrix.build_matrix.firmware }}
+          MACHINE: ${{ matrix.build_matrix.machine }}
+          LAVA_NAME: ${{ steps.get_lavaname.outputs.LAVANAME }}
 
       - name: Submit lava job
         id: submit_job
         run: |
           cd ../job_render
-          job_id=$(docker run -i --rm --workdir="$PWD" -v "$(dirname $PWD)":"$(dirname $PWD)" ${{ inputs.docker_image }} sh -c "lavacli identities add --token ${{secrets.LAVA_OSS_TOKEN}} --uri https://lava-oss.qualcomm.com/RPC2 --username ${{secrets.LAVA_OSS_USER}} production && lavacli -i production jobs submit ./renders/lava_job_definition.yaml")
+          job_id=$(docker run -i --rm --workdir="$PWD" -v "$(dirname $PWD)":"$(dirname $PWD)" ${{ inputs.docker_image }} sh -c "lavacli identities add --token ${{ secrets.LAVA_OSS_TOKEN }} --uri https://lava-oss.qualcomm.com/RPC2 --username ${{ secrets.LAVA_OSS_USER }} production && lavacli -i production jobs submit ./renders/lava_job_definition.yaml")
           job_url="https://lava-oss.qualcomm.com/scheduler/job/$job_id"
           echo "job_id=$job_id" >> $GITHUB_OUTPUT
           echo "job_url=$job_url" >> $GITHUB_OUTPUT
@@ -58,12 +96,12 @@ jobs:
         run: |
           STATE=""
           while [ "$STATE" != "Finished" ]; do
-            state=$(docker run -i --rm --workdir="$PWD" -v "$(dirname $PWD)":"$(dirname $PWD)" ${{ inputs.docker_image }} sh -c "lavacli identities add --token ${{secrets.LAVA_OSS_TOKEN}} --uri https://lava-oss.qualcomm.com/RPC2 --username ${{secrets.LAVA_OSS_USER}} production && lavacli -i production jobs show $JOB_ID" | grep state)
+            state=$(docker run -i --rm --workdir="$PWD" -v "$(dirname $PWD)":"$(dirname $PWD)" ${{ inputs.docker_image }} sh -c "lavacli identities add --token ${{ secrets.LAVA_OSS_TOKEN }} --uri https://lava-oss.qualcomm.com/RPC2 --username ${{ secrets.LAVA_OSS_USER }} production && lavacli -i production jobs show $JOB_ID" | grep state)
             STATE=$(echo "$state" | cut -d':' -f2 | sed 's/^ *//;s/ *$//')
             echo "Current status: $STATE"
             sleep 30
           done
-          health=$(docker run -i --rm --workdir="$PWD" -v "$(dirname $PWD)":"$(dirname $PWD)" ${{ inputs.docker_image }} sh -c "lavacli identities add --token ${{secrets.LAVA_OSS_TOKEN}} --uri https://lava-oss.qualcomm.com/RPC2 --username ${{secrets.LAVA_OSS_USER}} production && lavacli -i production jobs show $JOB_ID" | grep Health)
+          health=$(docker run -i --rm --workdir="$PWD" -v "$(dirname $PWD)":"$(dirname $PWD)" ${{ inputs.docker_image }} sh -c "lavacli identities add --token ${{ secrets.LAVA_OSS_TOKEN }} --uri https://lava-oss.qualcomm.com/RPC2 --username ${{ secrets.LAVA_OSS_USER }} production && lavacli -i production jobs show $JOB_ID" | grep Health)
           HEALTH=$(echo "$health" | cut -d':' -f2 | sed 's/^ *//;s/ *$//')
           if [[ "$HEALTH" == "Complete" ]]; then
             echo "Lava job passed."
@@ -95,4 +133,3 @@ jobs:
           </details>
           '
           echo -e "$SUMMARY" >> $GITHUB_STEP_SUMMARY
-

--- a/ci/MACHINES.json
+++ b/ci/MACHINES.json
@@ -1,0 +1,5 @@
+{
+    "qcs6490-rb3gen2": ["rb3gen2", "qcs6490"],
+    "qcs9100-ride-r3": ["sa8775p-ride", "qcs9100-ride"],
+    "qcs8300-ride": ["qcs8300-ride", "qcs8300-ride"]
+}


### PR DESCRIPTION
# Description

This PR introduces LAVA test automation for multiple hardware targets as defined in `MACHINES.json`. Each entry maps a DTB filename to its corresponding firmware and LAVA target name.

### Key improvements:

- Implements matrix builds for testing only, driven by structured MACHINES.json

- Optimizes build workflow by running a single unified kernel build

- Uploads all generated DTB files to AWS S3 for reuse across LAVA jobs

- Avoids redundant builds and ensures consistent artifacts across test