### PR TITLE
qcom-next.conf: Add gpu topic branch

### DIFF
--- a/qcom-next.conf
+++ b/qcom-next.conf
@@ -57,3 +57,4 @@ tech/all/dt/qcs9100        git@github.com:qualcomm-linux/kernel-topics.git      
 tech/all/dt/qcs8300        git@github.com:qualcomm-linux/kernel-topics.git       tech/all/dt/qcs8300
 tech/all/dt/qcs615         git@github.com:qualcomm-linux/kernel-topics.git       tech/all/dt/qcs615
 tech/all/config            git@github.com:qualcomm-linux/kernel-topics.git       tech/all/config
+tech/mm/gpu                git@github.com:qualcomm-linux/kernel-topics.git       tech/mm/gpu


### PR DESCRIPTION
Add tech/mm/gpu topic branch to qcom-next.conf file.