### PR TITLE
ci:Add Flatbuild generation Support

### DIFF
--- a/.github/actions/loading/action.yml
+++ b/.github/actions/loading/action.yml
@@ -11,6 +11,10 @@ outputs:
     description: full matrix containing lava devails
     value: ${{ steps.set-matrix.outputs.full_matrix }}
 
+  bootbins:
+    description: Boot Bins for targets to generate Flat Build
+    value: ${{ steps.set-matrix.outputs.bootbins }}
+
 runs:
   using: "composite"
   steps:
@@ -22,13 +26,20 @@ runs:
           const fs = require('fs');
           const path = require('path');
           const filePath = path.join(process.env.GITHUB_WORKSPACE, 'ci', 'MACHINES.json');
+          const binsFilePath = path.join(process.env.GITHUB_WORKSPACE, 'ci', 'bootbins.json')
           let file;
+          let binsFile;
           try {
+            if (!fs.existsSync(binsFilePath)) {
+              core.setFailed(`MACHINES.json not found at ${binsFilePath}`);
+              return;
+            }
             if (!fs.existsSync(filePath)) {
               core.setFailed(`MACHINES.json not found at ${filePath}`);
               return;
             }
             file = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+            binsFile = JSON.parse(fs.readFileSync(binsFilePath, 'utf-8'));
           } catch (err) {
             core.setFailed(`Failed to load or parse MACHINES.json: ${err.message}`);
             return;
@@ -46,3 +57,12 @@ runs:
           }));
           core.setOutput('full_matrix', JSON.stringify(complete_matrix));
           console.log(complete_matrix);
+
+          // Boot bins for FlatBuild
+          const bins_matrix = Object.entries(binsFile).map(([target, [buildid, firmwareid]]) => ({
+            target,
+            buildid,
+            firmwareid
+          }));
+          core.setOutput('bootbins', JSON.stringify(bins_matrix));
+          console.log(bins_matrix);

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,11 @@ on:
         type: string
         required: true
 
+      bootbins:
+        description: Boot bins for Flat META
+        type: string
+        required: true
+
 jobs:
   build:
     runs-on:
@@ -41,6 +46,78 @@ jobs:
         with:
           docker_image: ${{ inputs.docker_image }}
           workspace_path: ${{ steps.sync.outputs.workspace_path }}
+
+      - name: Generate Flat Build
+        run: |
+          set -x
+          bootbins='${{ inputs.bootbins }}'
+          echo "$bootbins"
+          workspace=${{ steps.sync.outputs.workspace_path }}
+          cd $workspace/../
+          git clone https://github.com/qualcomm-linux/qcom-ptool.git
+          for row in $(echo "$bootbins" | jq -c '.[]'); do
+          (
+            target=$(echo "$row" | jq -r '.target')
+            buildid=$(echo "$row" | jq -r '.buildid')
+            firmwareid=$(echo "$row" | jq -r '.firmwareid')
+            echo "DT : $target"
+            echo "BuildId : $buildid"
+            echo "FirmwareId : $firmwareid"
+            echo "-----------------------------"
+            platform=$(echo "$buildid" | cut -d '.' -f1)
+            echo "$platform"
+            mkdir -p $workspace/../flatbuild-"$platform"
+            cd $workspace/../flatbuild-"$platform"
+            wget https://artifactory-las.qualcomm.com/artifactory/lint-lv-local/k2c_nhlos_fw/$buildid/common/build/ufs/bin/"$platform"_bootbinaries.zip
+            unzip "$platform"_bootbinaries.zip
+            python $workspace/../qcom-ptool/ptool.py -x "$platform"_bootbinaries/partition_ufs.xml -t "$platform"_bootbinaries/
+            cd $workspace/../flatbuild-"$platform"/"$platform"_bootbinaries/
+            rm -rf rawprogram0_* rawprogram1_* rawprogram2_* rawprogram3_* rawprogram4_* rawprogram5_*
+            sed -i '/system.img/d' rawprogram0.xml
+            mkdir -p $workspace/../flatbuild-"$platform"/artifacts
+            cd $workspace/../flatbuild-"$platform"/artifacts
+
+            #This needs to be downloaded from S3 bucket.
+            wget http://hu-sgaud-hyd:8000/initramfs-kerneltest-full-image-qcom-armv8a.cpio.gz
+            wget http://hu-sgaud-hyd:8000/initramfs-firmware-"$firmwareid"-image-qcom-armv8a.cpio.gz
+
+            gunzip -c initramfs-kerneltest-full-image-qcom-armv8a.cpio.gz > initramfs-kerneltest-full-image-qcom-armv8a.cpio
+            gunzip -c initramfs-firmware-"$firmwareid"-image-qcom-armv8a.cpio.gz > initramfs-firmware-"$firmwareid"-image-qcom-armv8a.cpio
+            cat initramfs-kerneltest-full-image-qcom-armv8a.cpio initramfs-firmware-"$firmwareid"-image-qcom-armv8a.cpio > merged-initramfs-"$firmwareid".cpio
+            gzip merged-initramfs-"$firmwareid".cpio
+
+            (cd $workspace/../kobj/tar-install ; find lib/modules | cpio -o -H newc -R +0:+0 | gzip -9 >> $workspace/../flatbuild-"$platform"/artifacts/merged-initramfs-"$firmwareid".cpio.gz)
+
+            wget -O $workspace/../flatbuild-"$platform"/artifacts/systemd-boot-efi.deb http://ports.ubuntu.com/pool/universe/s/systemd/systemd-boot-efi_255.4-1ubuntu8_arm64.deb
+            dpkg-deb -xv $workspace/../flatbuild-"$platform"/artifacts/systemd-boot-efi.deb $workspace/../flatbuild-"$platform"/artifacts/systemd
+            cd $workspace/../flatbuild-"$platform"
+
+            docker run -i --rm \
+              --user $(id -u):$(id -g) \
+              --workdir="$PWD" \
+              -v "$(dirname $PWD)":"$(dirname $PWD)" \
+              ${{ inputs.docker_image }} bash -c "
+              generate_boot_bins.sh efi --ramdisk artifacts/merged-initramfs-"$firmwareid".cpio.gz \
+                --systemd-boot artifacts/systemd/usr/lib/systemd/boot/efi/systemd-bootaa64.efi \
+                --stub artifacts/systemd/usr/lib/systemd/boot/efi/linuxaa64.efi.stub \
+                --linux ../kobj/arch/arm64/boot/Image \
+                --output images
+            "
+            docker run -i --rm \
+              --user $(id -u):$(id -g) \
+              --workdir="$PWD" \
+              -v "$(dirname $PWD)":"$(dirname $PWD)" \
+              ${{ inputs.docker_image }} bash -c "
+                generate_boot_bins.sh dtb --input ../kobj/arch/arm64/boot/dts/qcom/"$target".dtb --output images
+            "
+
+            cp $workspace/../flatbuild-"$platform"/images/efi.bin $workspace/../flatbuild-"$platform"/"$platform"_bootbinaries
+            cp $workspace/../flatbuild-"$platform"/images/dtb.bin $workspace/../flatbuild-"$platform"/"$platform"_bootbinaries
+
+            #Upload these to location from where Axiom jobs can be triggered.
+            #$workspace/../flatbuild-"$platform"/"$platform"_bootbinaries
+          )
+          done
 
       - name: Create file list for artifacts upload
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,8 +69,11 @@ jobs:
             mkdir -p $workspace/../flatbuild-"$platform"
             cd $workspace/../flatbuild-"$platform"
             wget https://artifactory-las.qualcomm.com/artifactory/lint-lv-local/k2c_nhlos_fw/$buildid/common/build/ufs/bin/"$platform"_bootbinaries.zip
+            wget https://artifactory-las.qualcomm.com/artifactory/lint-lv-local/k2c_nhlos_fw/$buildid/common/build/ufs/bin/contents.zip
             unzip "$platform"_bootbinaries.zip
+            unzip contents.zip
             python $workspace/../qcom-ptool/ptool.py -x "$platform"_bootbinaries/partition_ufs.xml -t "$platform"_bootbinaries/
+            cp $workspace/../flatbuild-"$platform"/contents/contents.xml "$platform"_bootbinaries/
             cd $workspace/../flatbuild-"$platform"/"$platform"_bootbinaries/
             rm -rf rawprogram0_* rawprogram1_* rawprogram2_* rawprogram3_* rawprogram4_* rawprogram5_*
             sed -i '/system.img/d' rawprogram0.xml

--- a/.github/workflows/loading.yml
+++ b/.github/workflows/loading.yml
@@ -13,12 +13,17 @@ on:
         description: Full Matrix containing lava description
         value: ${{ jobs.loading.outputs.full_matrix }}
 
+      bootbins:
+        description: Bootbins to generate Flat Build
+        value: ${{ jobs.loading.outputs.bootbins }}
+
 jobs:
   loading:
     runs-on: ubuntu-latest
     outputs:
       build_matrix: ${{ steps.loading.outputs.build_matrix }}
       full_matrix: ${{ steps.loading.outputs.full_matrix }}
+      bootbins: ${{ steps.loading.outputs.bootbins }}
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4

--- a/.github/workflows/pre_merge.yml
+++ b/.github/workflows/pre_merge.yml
@@ -14,6 +14,7 @@ jobs:
     with:
       docker_image: kmake-image:ver.1.0
       build_matrix: ${{ needs.loading.outputs.build_matrix }}
+      bootbins: ${{ needs.loading.outputs.bootbins }}
 
   test:
     needs: [loading, build]

--- a/ci/bootbins.json
+++ b/ci/bootbins.json
@@ -1,0 +1,5 @@
+{
+   "qcs6490-rb3gen2":["QCM6490.LE.1.0-00368-STD.INT.SL-1","rb3gen2"],
+   "qcs9100-ride-r3":["QCS9100.LE.1.0.r1-00229-ADV.INT.SL-2","sa8775p-ride"],
+   "qcs8300-ride":["QCS8300.LE.1.0.r1-00125-ADV.INT.SL-2","qcs8300-ride"]
+}

--- a/ci/bootbins.json
+++ b/ci/bootbins.json
@@ -1,5 +1,5 @@
 {
-   "qcs6490-rb3gen2":["QCM6490.LE.1.0-00368-STD.INT.SL-1","rb3gen2"],
-   "qcs9100-ride-r3":["QCS9100.LE.1.0.r1-00229-ADV.INT.SL-2","sa8775p-ride"],
-   "qcs8300-ride":["QCS8300.LE.1.0.r1-00125-ADV.INT.SL-2","qcs8300-ride"]
+   "qcs6490-rb3gen2":["QCM6490.LE.1.0-00376-STD.PROD-1","rb3gen2"],
+   "qcs9100-ride-r3":["QCS9100.LE.1.0-00243-STD.PROD-1","sa8775p-ride"],
+   "qcs8300-ride":["QCS8300.LE.1.0-00137-STD.PROD-1","qcs8300-ride"]
 }


### PR DESCRIPTION
Add flatbuild generation support for the targets.
Target configuration is stored in a json file,
it also have Build Id, which is used to fetch boot binaries
from artifactory to generate flat build.