### PR TITLE
Add Hamoa topic branch

### DIFF
--- a/qcom-next.conf
+++ b/qcom-next.conf
@@ -56,5 +56,6 @@ tech/all/dt/qcs6490        git@github.com:qualcomm-linux/kernel-topics.git      
 tech/all/dt/qcs9100        git@github.com:qualcomm-linux/kernel-topics.git       tech/all/dt/qcs9100
 tech/all/dt/qcs8300        git@github.com:qualcomm-linux/kernel-topics.git       tech/all/dt/qcs8300
 tech/all/dt/qcs615         git@github.com:qualcomm-linux/kernel-topics.git       tech/all/dt/qcs615
+tech/all/dt/hamoa          git@github.com:qualcomm-linux/kernel-topics.git       tech/all/dt/hamoa
 tech/all/config            git@github.com:qualcomm-linux/kernel-topics.git       tech/all/config
 tech/mm/gpu                git@github.com:qualcomm-linux/kernel-topics.git       tech/mm/gpu


### PR DESCRIPTION
Add Hamoa topic branch to qcom-next.conf. Hamoa topic branch hosts Hamoa related device tree changes on qualcomm-linux