### PR TITLE
Added timeout and health check to LAVA job monitoring step

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,14 +95,22 @@ jobs:
         id: check_job
         run: |
           STATE=""
+          START_TIME=$(date +%s)
           while [ "$STATE" != "Finished" ]; do
             state=$(docker run -i --rm --workdir="$PWD" -v "$(dirname $PWD)":"$(dirname $PWD)" ${{ inputs.docker_image }} sh -c "lavacli identities add --token ${{ secrets.LAVA_OSS_TOKEN }} --uri https://lava-oss.qualcomm.com/RPC2 --username ${{ secrets.LAVA_OSS_USER }} production && lavacli -i production jobs show $JOB_ID" | grep state)
             STATE=$(echo "$state" | cut -d':' -f2 | sed 's/^ *//;s/ *$//')
             echo "Current status: $STATE"
+            CURRENT_TIME=$(date +%s)
+            ELAPSED_TIME=$(( (CURRENT_TIME - START_TIME) / 3600 ))
+            if [ $ELAPSED_TIME -ge 2 ]; then
+                 echo "Timeout: 2 hours elapsed.Lava job failed."
+                 summary=":x: Lava job failed."
+                 echo "summary=$summary" >> $GITHUB_OUTPUT
+                 exit 1
+            fi
             sleep 30
           done
-          health=$(docker run -i --rm --workdir="$PWD" -v "$(dirname $PWD)":"$(dirname $PWD)" ${{ inputs.docker_image }} sh -c "lavacli identities add --token ${{ secrets.LAVA_OSS_TOKEN }} --uri https://lava-oss.qualcomm.com/RPC2 --username ${{ secrets.LAVA_OSS_USER }} production && lavacli -i production jobs show $JOB_ID" | grep Health)
-          HEALTH=$(echo "$health" | cut -d':' -f2 | sed 's/^ *//;s/ *$//')
+          HEALTH=$(docker run -i --rm --workdir="$PWD" -v "$(dirname $PWD)":"$(dirname $PWD)" ${{ inputs.docker_image }} sh -c "lavacli identities add --token ${{ secrets.LAVA_OSS_TOKEN }} --uri https://lava-oss.qualcomm.com/RPC2 --username ${{ secrets.LAVA_OSS_USER }} production && lavacli -i production results  $JOB_ID" | grep fail || echo "Complete")
           if [[ "$HEALTH" == "Complete" ]]; then
             echo "Lava job passed."
             summary=":heavy_check_mark: Lava job passed."

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,10 +101,10 @@ jobs:
             STATE=$(echo "$state" | cut -d':' -f2 | sed 's/^ *//;s/ *$//')
             echo "Current status: $STATE"
             CURRENT_TIME=$(date +%s)
-            ELAPSED_TIME=$(( (CURRENT_TIME - START_TIME) / 3600 ))
+            ELAPSED_TIME=$(((CURRENT_TIME - START_TIME)/3600))
             if [ $ELAPSED_TIME -ge 2 ]; then
-                 echo "Timeout: 2 hours elapsed.Lava job failed."
-                 summary=":x: Lava job failed."
+                 echo "Timeout: 2 hours exceeded."
+                 summary=":x: Lava job exceeded time limit."
                  echo "summary=$summary" >> $GITHUB_OUTPUT
                  exit 1
             fi

--- a/README
+++ b/README
@@ -4,6 +4,6 @@ merge the various git topic branches and create a new integration branch
 
 Please send patches to update the qcom-next.conf file as per your team
 needs.
-
+ 
 There is also a ci.conf.sample file if you want to create your own
 configuration file for local integration testing.


### PR DESCRIPTION
- Introduced a 2-hour timeout to prevent infinite polling if the job hangs.
- Added a health check using `lavacli results` to determine if the job passed or failed.

