### PR TITLE
Add multi-target support for ubuntu build workflow

### DIFF
--- a/.github/actions/aws_s3_helper/action.yml
+++ b/.github/actions/aws_s3_helper/action.yml
@@ -101,6 +101,6 @@ runs:
       if: ${{ inputs.mode == 'multi-upload' }}
       uses: actions/upload-artifact@v4
       with:
-        name: presigned_urls.json
+        name: ${{ env.machine }}presigned_urls.json
         path: ${{ github.workspace }}/presigned_urls.json
         retention-days: 3

--- a/.github/actions/loading/action.yml
+++ b/.github/actions/loading/action.yml
@@ -15,6 +15,10 @@ outputs:
     description: Boot Bins for targets to generate Flat Build
     value: ${{ steps.set-matrix.outputs.bootbins }}
 
+  ubuntu_matrix:
+    description: Ubuntu matrix for generating packages
+    value: ${{ steps.ubuntu-matrix.outputs.ubuntu_matrix }}
+
 runs:
   using: "composite"
   steps:
@@ -25,44 +29,54 @@ runs:
         script: |
           const fs = require('fs');
           const path = require('path');
-          const filePath = path.join(process.env.GITHUB_WORKSPACE, 'ci', 'MACHINES.json');
-          const binsFilePath = path.join(process.env.GITHUB_WORKSPACE, 'ci', 'bootbins.json')
-          let file;
-          let binsFile;
+          const targetsPath = path.join(process.env.GITHUB_WORKSPACE, 'ci', 'MACHINES.json');
+          let targets;
           try {
-            if (!fs.existsSync(binsFilePath)) {
-              core.setFailed(`bootbins.json not found at ${binsFilePath}`);
+            if (!fs.existsSync(targetsPath)) {
+              core.setFailed(`MACHINES.json not found at ${targetsPath}`);
               return;
             }
-            if (!fs.existsSync(filePath)) {
-              core.setFailed(`MACHINES.json not found at ${filePath}`);
-              return;
-            }
-            file = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
-            binsFile = JSON.parse(fs.readFileSync(binsFilePath, 'utf-8'));
+            targets = JSON.parse(fs.readFileSync(targetsPath, 'utf-8'));
           } catch (err) {
             core.setFailed(`Failed to load or parse MACHINES.json: ${err.message}`);
             return;
           }
-          // Slim matrix for better job visibility
-          const slim_matrix = Object.entries(file).map(([machine, [firmware]]) => ({ machine, firmware }));
-          core.setOutput('build_matrix', JSON.stringify(slim_matrix));
-          console.log(slim_matrix);
+          // Build matrix: machine, firmware
+          const build_matrix = Object.values(targets).map(({ machine, firmware }) => ({ machine, firmware }));
+          core.setOutput('build_matrix', JSON.stringify(build_matrix));
+          console.log("Build Matrix:", build_matrix);
 
-          // Full matrix to pass to test jobs
-          const complete_matrix = Object.entries(file).map(([machine, [firmware, lavaname]]) => ({
-            machine,
-            firmware,
-            lavaname
-          }));
-          core.setOutput('full_matrix', JSON.stringify(complete_matrix));
-          console.log(complete_matrix);
-          
-          // Boot bins for FlatBuild
-          const bins_matrix = Object.entries(binsFile).map(([target, [buildid, firmwareid]]) => ({
-            target,
-            buildid,
-            firmwareid
-          }));
-          core.setOutput('bootbins', JSON.stringify(bins_matrix));
-          console.log(bins_matrix);
+          // Full matrix: machine, firmware, lavaname
+          const full_matrix = Object.values(targets).map(({ machine, firmware, lavaname }) => ({ machine, firmware, lavaname }));
+          core.setOutput('full_matrix', JSON.stringify(full_matrix));
+          console.log("Full Matrix:", full_matrix);
+
+          // Bootbins: target, buildid, firmwareid
+          const bootbins = Object.values(targets).map(({ target, buildid, firmwareid }) => ({ target, buildid, firmwareid }));
+          core.setOutput('bootbins', JSON.stringify(bootbins));
+          console.log("Boot Bins:", bootbins);
+
+    - name: Set Ubuntu Config Matrix
+      id: ubuntu-matrix
+      if: ${{ github.workflow == 'pre_merge_ubuntu' }}
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const fs = require('fs');
+          const path = require('path');
+          const ubuntuConfigPath = path.join(process.env.GITHUB_WORKSPACE, 'ci', 'UBUNTU_CONFIG.json');
+          let ubuntuConfig;
+          try {
+            if (!fs.existsSync(ubuntuConfigPath)) {
+              core.setFailed(`UBUNTU_CONFIG.json not found at ${ubuntuConfigPath}`);
+              return;
+            }
+            ubuntuConfig = JSON.parse(fs.readFileSync(ubuntuConfigPath, 'utf-8'));
+          } catch (err) {
+            core.setFailed(`Failed to load or parse UBUNTU_CONFIG.json: ${err.message}`);
+            return;
+          }
+          // Build matrix: os, kernel, firmware
+          const ubuntu_matrix = Object.values(ubuntuConfig).map(obj => Object.fromEntries(Object.entries(obj)));
+          core.setOutput('ubuntu_matrix', JSON.stringify(ubuntu_matrix));
+          console.log("Ubuntu Matrix:", ubuntu_matrix); 

--- a/.github/actions/pull_docker_image/action.yml
+++ b/.github/actions/pull_docker_image/action.yml
@@ -7,6 +7,11 @@ inputs:
     required: true
     default: kmake-image:ver.1.0
 
+  tag:
+    description: The tag to apply to the pulled image
+    required: false
+    default: ver.1.0
+
 runs:
   using: "composite"
   steps:
@@ -16,4 +21,4 @@ runs:
         echo "Pulling Docker image: ${{ inputs.image }}"
         docker pull artifacts.codelinaro.org/clo-420-qli-registry/${{ inputs.image }}
         echo "Docker image pulled successfully:"
-        docker tag artifacts.codelinaro.org/clo-420-qli-registry/${{ inputs.image }} kmake-image:ver.1.0
+        docker tag artifacts.codelinaro.org/clo-420-qli-registry/${{ inputs.image }} kmake-image:${{ inputs.tag }}

--- a/.github/workflows/pre-merge-ubuntu.yml
+++ b/.github/workflows/pre-merge-ubuntu.yml
@@ -1,0 +1,108 @@
+---
+name: pre_merge_ubuntu
+run-name: Generate Ubuntu Packages
+
+on:
+  workflow_dispatch:
+    inputs:
+      qcom-build-utils-pr-number:
+        description: qcom-build-utils-pr-number (keep empty to use `latest` branch)
+        required: false
+        type: string
+      pr:
+        description: Pull request number
+        type: string
+        required: false
+      sha:
+        description: Head sha of the PR
+        type: string
+        required: false
+      ref:
+        description: Target branch
+        type: string
+        required: false
+      repo:
+        description: Target repository
+        type: string
+        required: false
+
+jobs:
+  init-status:
+    name: Initialize Status
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set Status
+        uses: qualcomm-linux/kernel-config/.github/actions/workflow_status@main
+        with:
+          sha: ${{ github.event.inputs.sha || github.sha }}
+          action_mode: start
+          check_name: "Ubuntu Package Generation"
+          repo: ${{ github.event.inputs.repo || github.repository }}
+          GH_TOKEN: ${{ secrets.PAT }}
+
+  init:
+    name: Initialize Workflow
+    needs: init-status
+    runs-on: ubuntu-latest
+    outputs:
+      commit_sha: ${{ steps.get_sha.outputs.commit_sha }}
+    steps:
+      - name: Checkout qcom-build-utils
+        uses: actions/checkout@v4
+        with:
+          repository: qualcomm-linux/qcom-build-utils
+          token: ${{ secrets.PAT }}
+
+      - name: Get commit sha
+        id: get_sha
+        run: |
+          echo "${{ secrets.PAT }}" | gh auth login --with-token
+          if [ -n "${{ github.event.inputs.qcom-build-utils-pr-number }}" ]; then
+           # fetch latest commit hash from the PR branch
+            commit_sha=$(gh pr view ${{ github.event.inputs.qcom-build-utils-pr-number }} --json commits --jq '.commits[-1].oid')
+            echo "commit_sha=${commit_sha}" >> "$GITHUB_OUTPUT"
+          else
+            # use the latest commit hash from the latest branch
+            commit_sha=$(gh api repos/qualcomm-linux/qcom-build-utils/branches/latest --jq '.commit.sha')
+            echo "commit_sha=${commit_sha}" >> "$GITHUB_OUTPUT"
+          fi
+          echo "commit_sha=${commit_sha}"
+      - name: Update Summary
+        run: |
+          echo "## Ubuntu Package Generation" >> $GITHUB_STEP_SUMMARY
+          echo "- Pull Request Number: \`${{ github.event.inputs.pr || 'N/A' }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- Head Commit SHA: \`${{ github.event.inputs.sha || 'N/A' }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- Target Branch: \`${{ github.event.inputs.ref || 'N/A' }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- Target Repository: \`${{ github.event.inputs.repo || 'N/A' }}\`" >> $GITHUB_STEP_SUMMARY
+  loading:
+    name: Load Parameters
+    needs: init-status
+    uses: qualcomm-linux/kernel-config/.github/workflows/loading.yml@main
+    secrets: inherit
+
+  generate_debians:
+    name: Generate Debian Packages
+    needs: [init-status, init, loading]
+    uses: qualcomm-linux/kernel-config/.github/workflows/ubuntu-package-generation.yml@main
+    secrets: inherit
+    with:
+      pr: ${{ github.event.inputs.pr || '' }}
+      ref: ${{ github.event.inputs.ref || 'qcom-next' }}
+      build_utils_ref: ${{ needs.init.outputs.commit_sha }}
+      repo: ${{ github.event.inputs.repo || 'qualcomm-linux-stg/kernel' }}
+      build_matrix: ${{ needs.loading.outputs.ubuntu_matrix }}
+
+  final-status:
+    name: Finalize Status
+    if: always()
+    runs-on: ubuntu-latest
+    needs: generate_debians
+    steps:
+      - name: Set final status
+        uses: qualcomm-linux/kernel-config/.github/actions/workflow_status@main
+        with:
+          sha: ${{ github.event.inputs.sha || github.sha }}
+          action_mode: ${{ needs.generate_debians.result }}
+          check_name: "Ubuntu Package Generation"
+          repo: ${{ github.event.inputs.repo || github.repository }}
+          GH_TOKEN: ${{ secrets.PAT }}

--- a/.github/workflows/ubuntu-package-generation.yml
+++ b/.github/workflows/ubuntu-package-generation.yml
@@ -1,230 +1,62 @@
 ---
-name: ubuntu_package_generation
-run-name: Generate Ubuntu Packages
+name: _ubuntu
+description: Reusable workflow for ubuntu package generation
 
 on:
-  workflow_dispatch:
+  workflow_call:
     inputs:
-      qcom-build-utils-pr-number:
-        description: PR number to take the latest changes from (keep to use `ubuntu-noble-arm64` branch)
-        required: false
-        type: string
-      pr:
-        description: Pull request number
-        type: string
-        required: false
-      sha:
-        description: Head sha of the PR
-        type: string
-        required: false
-      ref:
-        description: Target branch
-        type: string
-        required: false
       repo:
-        description: Target repository
-        type: string
+        description: 'Repo Name'
         required: false
+        type: string
+      ref:
+        description: 'Branch or tag name'
+        required: false
+        type: string
+      build_utils_ref:
+        description: 'Reference for qcom-build-utils (latest commit sha)'
+        required: false
+        type: string
+        default: 'latest'
+      pr:
+        description: 'Pull Request Number'
+        required: false
+        type: string
+        default: ''
+      build_matrix:
+        description: 'Build matrix for parallel builds'
+        required: true
+        type: string
 
 jobs:
-  init-status:
-    name: Initialize Status
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set Status
-        uses: qualcomm-linux/kernel-config/.github/actions/workflow_status@main
-        with:
-          sha: ${{ github.event.inputs.sha || github.sha }}
-          action_mode: start
-          check_name: "Ubuntu Package Generation"
-          repo: ${{ github.event.inputs.repo || github.repository }}
-          GH_TOKEN: ${{ secrets.PAT }}
-
-  init:
-    name: Initialize Workflow
-    needs: init-status
-    runs-on: ubuntu-latest
-    outputs:
-      commit_sha: ${{ steps.get_sha.outputs.commit_sha }}
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v4
-        with:
-          repository: qualcomm-linux/qcom-build-utils
-          token: ${{ secrets.PAT }}
-
-      - name: Get commit sha
-        id: get_sha
-        run: |
-          echo "${{ secrets.PAT }}" | gh auth login --with-token
-          if [ -n "${{ github.event.inputs.qcom-build-utils-pr-number }}" ]; then
-           # fetch latest commit hash from the PR branch
-            commit_sha=$(gh pr view ${{ github.event.inputs.qcom-build-utils-pr-number }} --json commits --jq '.commits[-1].oid')
-            echo "commit_sha=${commit_sha}" >> "$GITHUB_OUTPUT"
-          else
-            # use the latest commit hash from the latest branch
-            commit_sha=$(gh api repos/qualcomm-linux/qcom-build-utils/branches/latest --jq '.commit.sha')
-            echo "commit_sha=${commit_sha}" >> "$GITHUB_OUTPUT"
-          fi
-          echo "commit_sha=${commit_sha}"
-
-      - name: Update Summary
-        run: |
-          echo "## Ubuntu Package Generation" >> $GITHUB_STEP_SUMMARY
-          echo "- Pull Request Number: \`${{ github.event.inputs.pr || 'N/A' }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "- Head Commit SHA: \`${{ inputs.sha || 'N/A' }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "- Target Branch: \`${{ github.event.inputs.ref || 'N/A' }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "- Target Repository: \`${{ github.event.inputs.repo || 'N/A' }}\`" >> $GITHUB_STEP_SUMMARY
-
   generate_debians:
-    name: Generate Debian Packages
-    needs: [init-status, init]
+    name: Build
     runs-on:
       group: GHA-Kernel-SelfHosted-RG
       labels: [self-hosted, kernel-prd-u2404-arm64-xlrg-od-ephem]
+    strategy:
+      fail-fast: false
+      matrix:
+        ubuntu_matrix: ${{ fromJson(inputs.build_matrix) }}
     steps:
-      - name: Checkout qcom-build-utils repository
+      - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Build Ubuntu packages
+        id: build
+        uses: qualcomm-linux/kernel-config/.github/actions/build_ubuntu@main
         with:
-          repository: qualcomm-linux/qcom-build-utils
-          ref: ${{ needs.init.outputs.commit_sha }}
+          repo: ${{ inputs.repo }}
+          ref: ${{ inputs.ref }}
+          build_utils_ref: ${{ inputs.build_utils_ref }}
+          pr: ${{ inputs.pr }}
+          bootbin: ${{ matrix.ubuntu_matrix.bootbin }}
+          content: ${{ matrix.ubuntu_matrix.content }}
+          machine: ${{ matrix.ubuntu_matrix.machine }}
+          target: ${{ matrix.ubuntu_matrix.target }}
+          efi: ${{ matrix.ubuntu_matrix.efi }}
+          firmware: ${{ matrix.ubuntu_matrix.firmware }}
+        env:
           token: ${{ secrets.PAT }}
-
-      - name: Pull docker image
-        run: |
-          docker pull artifacts.codelinaro.org/clo-420-qli-registry/kmake-image-ubuntu-noble-arm64:ver.1.0
-          docker tag artifacts.codelinaro.org/clo-420-qli-registry/kmake-image-ubuntu-noble-arm64:ver.1.0 kmake-image:ubuntu-noble-arm64
-
-      - name: Setup git config
-        run: |
-          git config --global user.name "QLI CI Bot"
-          git config --global user.email "qualcomm-linux@qualcomm.com"
-
-      - name: Configure AWS
-        uses: aws-actions/configure-aws-credentials@v2
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-west-2
-
-      - name: Sync kernel codebase
-        id: sync
-        run: |
-          cd kernel && export BUILD_TOP=`pwd`
-          if [ -z "${{ github.event.inputs.repo }}" ]; then
-            echo "No repository specified, using default: qualcomm-linux/kernel"
-            export REPO="qualcomm-linux/kernel"
-          else
-            export REPO="${{ github.event.inputs.repo }}"
-          fi
-          if [ -z "${{ github.event.inputs.ref }}" ]; then
-            echo "No branch specified, using default: qcom-next"
-            export BRANCH="qcom-next"
-          else
-            export BRANCH="${{ github.event.inputs.ref }}"
-          fi
-          echo "Syncing ${REPO} branch ${BRANCH}"
-          git clone https://${{ secrets.PAT }}@github.com/${REPO}.git --single-branch -b ${BRANCH} --depth=1 $BUILD_TOP/qcom-next
-          if [ -z "${{ github.event.inputs.pr }}" ]; then
-            echo "No PR number specified, skipping merge."
-            echo "build_top=$BUILD_TOP" >> "$GITHUB_ENV"
-            exit 0
-          fi
-          echo "Merging PR #${{ github.event.inputs.pr }}"
-          cd $BUILD_TOP/qcom-next
-          git fetch https://${{ secrets.PAT }}@github.com/${REPO}.git pull/${{ github.event.inputs.pr }}/head:pr-${{ github.event.inputs.pr }}
-          git merge pr-${{ github.event.inputs.pr }} --no-commit || echo "Merge already applied or fast-forwarded"
-          if ! git diff --cached --quiet; then
-            git commit -m "Merged PR #${{ github.event.inputs.pr }}"
-          else
-            echo "Nothing to commit. PR may already be merged or fast-forwarded."
-          fi
-          echo "build_top=$BUILD_TOP" >> "$GITHUB_ENV"
-
-      - name: Add Kernel SQUASHFS configs required for Ubuntu
-        run: |
-          ./kernel/scripts/enable_squashfs_configs.sh ${{ env.build_top }}/qcom-next/
-
-      - name: Run build script
-        run: |
-          docker run -i \
-          --privileged --rm -v $PWD:$PWD --workdir="$PWD" kmake-image:ubuntu-noble-arm64 \
-          -c '
-            cd kernel
-            export BUILD_TOP=${{ env.build_top }}
-            ./scripts/build_kernel.sh
-          '
-
-      - name: Generate Linux Kernel Debian Package
-        run: |
-          docker run -i \
-          --privileged --rm -v $PWD:$PWD --workdir="$PWD" kmake-image:ubuntu-noble-arm64 \
-          -c '
-            cd kernel
-            # Run build-kernel-deb.sh and pass as argument the directory where kernel build artifacts were deployed (out/)
-            ./scripts/build-kernel-deb.sh out/
-          '
-
-      - name: Get built kernel version
-        id: get_kernel_version
-        run: |
-          cd kernel
-          kernel_version=$(ls *.deb)
-          echo "kernel_version=${kernel_version}" >> "$GITHUB_OUTPUT"
-
-      - name: Download EFI System Partition Image
-        uses: qualcomm-linux/kernel-config/.github/actions/aws_s3_helper@main
-        with:
-          s3_bucket: qli-prd-kernel-gh-artifacts
-          mode: download
-          download_file: qualcomm-linux/kernel/ubuntu-static-efi/efiesp.bin
-
-      - name: Download firmware debian package for X Elite CRD
-        uses: qualcomm-linux/kernel-config/.github/actions/aws_s3_helper@main
-        with:
-          s3_bucket: qli-prd-kernel-gh-artifacts
-          mode: download
-          download_file: kernel/ubuntu-firmware/linux-firmware-xelite_1.0-1+noble_arm64.deb
-
-      - name: Build Ubuntu rootfs
-        run: |
-          docker run -i \
-          --privileged --rm -v /dev:/dev -v $PWD:$PWD --workdir="$PWD" kmake-image:ubuntu-noble-arm64 \
-          -c '
-            ./rootfs/scripts/build-ubuntu-rootfs.sh kernel/${{ steps.get_kernel_version.outputs.kernel_version }} linux-firmware-xelite_1.0-1+noble_arm64.deb
-          '
-
-      - name: Create file list for artifacts upload
-        run: |
-          touch ${{ github.workspace }}/file_list.txt
-          echo "${{ github.workspace }}/ubuntu.img" >> ${{ github.workspace }}/file_list.txt
-          echo "${{ github.workspace }}/kernel/${{ steps.get_kernel_version.outputs.kernel_version }}" >> ${{ github.workspace }}/file_list.txt
-
-      - name: Upload artifacts to S3
-        uses: qualcomm-linux/kernel-config/.github/actions/aws_s3_helper@main
-        with:
-          s3_bucket: qli-prd-kernel-gh-artifacts
-          local_file: ${{ github.workspace }}/file_list.txt
-          mode: multi-upload
-
-      - name: Cleanup
-        if: always()
-        run: |
-          docker run -i \
-          --privileged --rm -v $PWD:$PWD --workdir="$PWD" kmake-image:ubuntu-noble-arm64 \
-          -c 'rm -rf ${{ github.workspace }}/*'
-
-  final-status:
-    name: Finalize Status
-    if: always()
-    runs-on: ubuntu-latest
-    needs: generate_debians
-    steps:
-      - name: Set final status
-        uses: qualcomm-linux/kernel-config/.github/actions/workflow_status@main
-        with:
-          sha: ${{ github.event.inputs.sha || github.sha }}
-          action_mode: ${{ needs.generate_debians.result }}
-          check_name: "Ubuntu Package Generation"
-          repo: ${{ github.event.inputs.repo || github.repository }}
-          GH_TOKEN: ${{ secrets.PAT }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/ci/MACHINES.json
+++ b/ci/MACHINES.json
@@ -1,5 +1,26 @@
 {
-    "qcs6490-rb3gen2": ["rb3gen2", "qcs6490"],
-    "qcs9100-ride-r3": ["sa8775p-ride", "qcs9100-ride"],
-    "qcs8300-ride": ["qcs8300-ride", "qcs8300-ride"]
+  "qcs6490-rb3gen2": {
+    "machine": "qcs6490-rb3gen2",
+    "firmware": "rb3gen2",
+    "lavaname": "qcs6490",
+    "target": "qcs6490-rb3gen2",
+    "buildid": "QCM6490.LE.1.0-00376-STD.PROD-1",
+    "firmwareid": "rb3gen2"
+  },
+  "qcs9100-ride-r3": {
+    "machine": "qcs9100-ride-r3",
+    "firmware": "sa8775p-ride",
+    "lavaname": "qcs9100-ride",
+    "target": "qcs9100-ride-r3",
+    "buildid": "QCS9100.LE.1.0-00243-STD.PROD-1",
+    "firmwareid": "sa8775p-ride"
+  },
+  "qcs8300-ride": {
+    "machine": "qcs8300-ride",
+    "firmware": "qcs8300-ride",
+    "lavaname": "qcs8300-ride",
+    "target": "qcs8300-ride",
+    "buildid": "QCS8300.LE.1.0-00137-STD.PROD-1",
+    "firmwareid": "qcs8300-ride"
+  }
 }

--- a/ci/UBUNTU_CONFIG.json
+++ b/ci/UBUNTU_CONFIG.json
@@ -1,0 +1,18 @@
+{
+    "hamoa": {
+        "machine": "hamoa",
+        "target": "hamoa",
+        "firmware": "kernel/ubuntu-firmware/linux-firmware-xelite_1.0-1+noble_arm64.deb",
+        "efi": "qualcomm-linux/kernel/ubuntu-static-efi/efiesp.bin",
+        "bootbin": "",
+        "content": ""
+    },
+    "qcs6490-rb3gen2": {
+        "machine": "qcs6490-rb3gen2",
+        "target": "KLM",
+        "firmware": "kernel/ubuntu-firmware/linux-firmware_20250317.git1d4c88ee-0ubuntu1.3_arm64.deb",
+        "efi": "qualcomm-linux/kernel/ubuntu-static-efi/efiesp.bin",
+        "bootbin": "QCM6490.LE.1.0-00376-STD.PROD-1/QCM6490_bootbinaries.zip",
+        "content": "QCM6490.LE.1.0-00376-STD.PROD-1/contents.zip"
+    }
+}


### PR DESCRIPTION
# Description:

This pull request adds a workflow `pre-merge-ubuntu.yml` that will serve as the entrypoint workflow for the ubuntu build workflow. The `ubuntu_package-generation.yml` serves as a reusable workflow using `build_ubuntu` action to perform required tasks.

### New files added:
- `pre-merge-ubuntu.yml`: This is a new workflow created to serve as entrypoint for the ubuntu workflow as the previous workflow `ubuntu-package-generation.yml` will now serve as a reusable workflow.
- `UBUNTU_CONFIG.json`: This is a JSON file containing the required config information to support multi-target builds.(helps in triggering matrix build)

### This commit also fixes:
- The `aws_s3_helper` action to upload the artifacts with the filename prefixed with machine name.
- The `loading` action to accomodate the changes done in `MACHINES.json` and also process the new JSON file added for ubuntu configuration.
- The `pull_docker_image` action to add a new input variable called `tag`, which can be used to specify the tag to be applied to the pulled image for easy reference in workflows.
- The `MACHINES.json` to add more concise information about multiple targets removing dependency of the existing `bootbins.json` file.


This PR is dependent on: https://github.com/qualcomm-linux/kernel-config/pull/52