### PR TITLE
Discard `bootbins.json` file

### DIFF
--- a/ci/bootbins.json
+++ b/ci/bootbins.json
@@ -1,5 +1,0 @@
-{
-   "qcs6490-rb3gen2":["QCM6490.LE.1.0-00376-STD.PROD-1","rb3gen2"],
-   "qcs9100-ride-r3":["QCS9100.LE.1.0-00243-STD.PROD-1","sa8775p-ride"],
-   "qcs8300-ride":["QCS8300.LE.1.0-00137-STD.PROD-1","qcs8300-ride"]
-}


### PR DESCRIPTION
# Description

This pull request removes the bootbins.json file as it is no longer needed, The need of this file is handled in the `MACHINES.json` file with required updates in the loading action to accomodate these changes.

This PR depends on - #53 