### PR TITLE
Separete coral template from .github/workflows directory

### DIFF
--- a/.github/templates/coral-kernel-template.yaml
+++ b/.github/templates/coral-kernel-template.yaml
@@ -81,6 +81,18 @@ on:
               - type: required
                 message: Kernel Checker GitHub Workflow ID is required
 
+      workflow.ubuntu.id:
+        type: number
+        required: true
+        coral.actions/metadata:
+          ui-annotations:
+            type: Number
+            label: pre_merge_ubuntu Workflow ID
+            description: ID of the Ubuntu Package Generation Workflow to be executed
+            rules:
+              - type: required
+                message: Ubuntu package generation Workflow ID
+
       labels:
         type: string
         coral.actions/metadata:


### PR DESCRIPTION
# Description

This commit separates the coral template to a separate templates directory instead of having in the workflows directory. The issue with the template having in the workflows directory is that the github treats tevery `.yml` file inside of the `.github/workflows` directory as a workflow file, having the coral template in the same directory was a issue for the github actions UI.