### PR TITLE
fix: configure AWS credentials for longer presigned URL expiry

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,6 +94,13 @@ jobs:
             echo "$workspace/"$platform"_bootbinaries.tar.gz" >> $workspace/../artifacts/file_list.txt
           done
 
+      - name: Configure AWS
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-west-2
+
       - name: Upload artifacts
         id: upload-artifacts
         uses: qualcomm-linux/kernel-config/.github/actions/aws_s3_helper@main


### PR DESCRIPTION
Update AWS credential setup to support generation of presigned URLs with extended expiration time. This improves accessibility for LAVA tests that require prolonged access.