### PR TITLE
Restrict LAVA testing to Kernel repository

### DIFF
--- a/.github/workflows/pre_merge.yml
+++ b/.github/workflows/pre_merge.yml
@@ -49,6 +49,7 @@ jobs:
       bootbins: ${{ needs.loading.outputs.bootbins }}
 
   check_run:
+    if: inputs.repo == 'qualcomm-linux/kernel'
     runs-on: ubuntu-latest
     needs: [init-status, loading, build]
     steps:
@@ -62,6 +63,7 @@ jobs:
           PVK: ${{ secrets.PVK }}
 
   test:
+    if: inputs.repo == 'qualcomm-linux/kernel'
     needs: [init-status, loading, build]
     uses: qualcomm-linux/kernel-config/.github/workflows/test.yml@main
     secrets: inherit


### PR DESCRIPTION
Trigger LAVA and check_run only if the target is qualcomm-linux/Kernel
repository. Skip LAVA execution for kernel-topics repository.

Rationale: LAVA lab currently has limited device availability.
This restriction helps conserve resources and may be revisited in the future.