### PR TITLE
ci(fix): update trigger condition for lava status comment job

### DIFF
--- a/.github/workflows/pre_merge.yml
+++ b/.github/workflows/pre_merge.yml
@@ -75,7 +75,7 @@ jobs:
   comment:
     needs: [test]
     uses: qualcomm-linux/kernel-config/.github/workflows/comment.yml@main
-    if: needs.test.result != 'skipped' 
+    if: always() && needs.test.result != 'skipped' 
     secrets: inherit
     with:
       pr_number: ${{ inputs.pr }}


### PR DESCRIPTION
The PR comment job is not being triggered when LAVA jobs are failing. The job should be triggered if LAVA jobs are triggered - either passing or failing. It should only be skipped if LAVA jobs are skipped.