### PR TITLE
ci : Enable Ubuntu workflow for QCS9100 and QCS8300

### DIFF
--- a/ci/UBUNTU_CONFIG.json
+++ b/ci/UBUNTU_CONFIG.json
@@ -14,5 +14,21 @@
         "efi": "qualcomm-linux/kernel/ubuntu-static-efi/efiesp.bin",
         "bootbin": "QCM6490.LE.1.0-00376-STD.PROD-1/QCM6490_bootbinaries.zip",
         "content": "QCM6490.LE.1.0-00376-STD.PROD-1/contents.zip"
+    },
+    "qcs9100-ride-r3": {
+        "machine": "qcs9100-ride-r3",
+        "target": "KLM",
+        "firmware": "kernel/ubuntu-firmware/linux-firmware_20250317.git1d4c88ee-0ubuntu1.3_arm64.deb",
+        "efi": "qualcomm-linux/kernel/ubuntu-static-efi/efiesp.bin",
+        "bootbin": "QCS9100.LE.1.0-00243-STD.PROD-1/QCS9100_bootbinaries.zip",
+        "content": "QCS9100.LE.1.0-00243-STD.PROD-1/contents.zip"
+    },
+    "qcs8300-ride": {
+        "machine": "qcs8300-ride",
+        "target": "KLM",
+        "firmware": "kernel/ubuntu-firmware/linux-firmware_20250317.git1d4c88ee-0ubuntu1.3_arm64.deb",
+        "efi": "qualcomm-linux/kernel/ubuntu-static-efi/efiesp.bin",
+        "bootbin": "QCS8300.LE.1.0-00137-STD.PROD-1/QCS8300_bootbinaries.zip",
+        "content": "QCS8300.LE.1.0-00137-STD.PROD-1/contents.zip"
     }
 }


### PR DESCRIPTION
Enable Ubuntu workflow for QCS9100 and QCS8300, this will generate flat builds for below targets :  QCS9100
QCS8300