### PR TITLE
Fix to keep only rawprogram*.xml from rawprogram xmls

### DIFF
--- a/.github/actions/build_ubuntu/action.yml
+++ b/.github/actions/build_ubuntu/action.yml
@@ -238,7 +238,7 @@ runs:
         fi
         cp -f contents/* $bootbin_dirname/
         cd $bootbin_dirname
-        rm -rf rawprogram{0..5}_*
+        rm -rf rawprogram{0..5}_* *_rawprogram_*
         echo "bootbin_dirname=$bootbin_dirname" >> "$GITHUB_OUTPUT"
         echo "::endgroup::"
 


### PR DESCRIPTION
# Description

This PR adds a fix to keep only keep only the rawprogram*.xml and patch*.xml from the xmls side of rawprogram.
The reason being in pcat flashing the mapping of xml to patch gets mismatch.

<img width="1513" height="631" alt="image" src="https://github.com/user-attachments/assets/f10fef32-52ea-445e-b2bf-def602f973a0" />
