### PR TITLE
ci : Enable Tests for sm8750-mtp target in CI

### DIFF
--- a/.github/actions/flat_meta_generation/action.yml
+++ b/.github/actions/flat_meta_generation/action.yml
@@ -85,14 +85,19 @@ runs:
           cd "$artifacts_dir"
 
           aws s3 cp "s3://$s3_bucket/meta-qcom/initramfs-kerneltest-full-image-qcom-armv8a.cpio.gz" .
-          aws s3 cp "s3://$s3_bucket/meta-qcom/initramfs-firmware-$firmwareid-image-qcom-armv8a.cpio.gz" .
 
-          gunzip -c initramfs-kerneltest-full-image-qcom-armv8a.cpio.gz > kerneltest.cpio
-          gunzip -c initramfs-firmware-$firmwareid-image-qcom-armv8a.cpio.gz > firmware.cpio
-          cat kerneltest.cpio firmware.cpio > merged-initramfs-$firmwareid.cpio
-          gzip merged-initramfs-$firmwareid.cpio
+          if [ -n "$firmwareid" ]; then
+            gunzip -c initramfs-kerneltest-full-image-qcom-armv8a.cpio.gz > kerneltest.cpio
+            aws s3 cp "s3://$s3_bucket/meta-qcom/initramfs-firmware-$firmwareid-image-qcom-armv8a.cpio.gz" .
+            gunzip -c initramfs-firmware-$firmwareid-image-qcom-armv8a.cpio.gz > firmware.cpio
+            cat kerneltest.cpio firmware.cpio > initramfs-$target.cpio
+            gzip initramfs-$target.cpio
+          else
+            echo "Firmware not available for Target : $target"
+            mv initramfs-kerneltest-full-image-qcom-armv8a.cpio.gz initramfs-$target.cpio.gz
+          fi
 
-          (cd "$workspace/../kobj/tar-install" && find lib/modules | cpio -o -H newc -R +0:+0 | gzip -9 >> "$artifacts_dir/merged-initramfs-$firmwareid.cpio.gz")
+          (cd "$workspace/../kobj/tar-install" && find lib/modules | cpio -o -H newc -R +0:+0 | gzip -9 >> "$artifacts_dir/initramfs-$target.cpio.gz")
 
           wget -O systemd-boot-efi.deb http://ports.ubuntu.com/pool/universe/s/systemd/systemd-boot-efi_255.4-1ubuntu8_arm64.deb
           dpkg-deb -xv systemd-boot-efi.deb systemd
@@ -104,7 +109,7 @@ runs:
             -v "$(dirname "$PWD")":"$(dirname "$PWD")" \
             "$docker_image" bash -c "
               generate_boot_bins.sh efi \
-                --ramdisk artifacts/merged-initramfs-$firmwareid.cpio.gz \
+                --ramdisk artifacts/initramfs-$target.cpio.gz \
                 --systemd-boot artifacts/systemd/usr/lib/systemd/boot/efi/systemd-bootaa64.efi \
                 --stub artifacts/systemd/usr/lib/systemd/boot/efi/linuxaa64.efi.stub \
                 --linux ../kobj/arch/arm64/boot/Image \

--- a/.github/actions/flat_meta_generation/action.yml
+++ b/.github/actions/flat_meta_generation/action.yml
@@ -45,6 +45,11 @@ runs:
           echo "Firmware ID : $firmwareid"
           echo "-----------------------------"
 
+          if [ -z "$buildid" ]; then
+            echo "No Build Id for $target, skip generating Flat Build."
+            continue
+          fi
+
           platform=$(echo "$buildid" | cut -d '.' -f1)
           build_dir="$workspace/../flatbuild-$platform"
           boot_dir="$build_dir/${platform}_bootbinaries"

--- a/.github/actions/lava_job_render/action.yml
+++ b/.github/actions/lava_job_render/action.yml
@@ -120,7 +120,7 @@ runs:
       run: |
         cd ../job_render
         ramdisk_url="$(aws s3 presign s3://qli-prd-kernel-gh-artifacts/meta-qcom/initramfs-kerneltest-full-image-qcom-armv8a.cpio.gz --expires 7600)"
-        firmware_url="$(aws s3 presign s3://qli-prd-kernel-gh-artifacts/meta-qcom/initramfs-firmware-${{ env.FIRMWARE }}-image-qcom-armv8a.cpio.gz --expires 7600)"
+
         # using ramdisk_url
         docker run -i --rm \
           --user "$(id -u):$(id -g)" \
@@ -131,13 +131,16 @@ runs:
           jq '.artifacts.ramdisk = env.ramdisk_url' data/cloudData.json > temp.json && mv temp.json data/cloudData.json
 
         # using firmware_url
-        docker run -i --rm \
-          --user "$(id -u):$(id -g)" \
-          --workdir="$PWD" \
-          -v "$(dirname "$PWD")":"$(dirname "$PWD")" \
-          -e firmware_url="$firmware_url" \
-          ${{ inputs.docker_image }} \
-          jq '.artifacts.firmware = env.firmware_url' data/cloudData.json > temp.json && mv temp.json data/cloudData.json
+        if [ -n "${{ env.FIRMWARE }}" ]; then
+          firmware_url="$(aws s3 presign s3://qli-stg-kernel-gh-artifacts/meta-qcom/initramfs-firmware-${{ env.FIRMWARE }}-image-qcom-armv8a.cpio.gz --expires 7600)"
+          docker run -i --rm \
+            --user "$(id -u):$(id -g)" \
+            --workdir="$PWD" \
+            -v "$(dirname "$PWD")":"$(dirname "$PWD")" \
+            -e firmware_url="$firmware_url" \
+            ${{ inputs.docker_image }} \
+            jq '.artifacts.firmware = env.firmware_url' data/cloudData.json > temp.json && mv temp.json data/cloudData.json
+        fi
 
     - name: Create lava_job_definition
       shell: bash

--- a/ci/MACHINES.json
+++ b/ci/MACHINES.json
@@ -22,5 +22,13 @@
     "target": "qcs8300-ride",
     "buildid": "QCS8300.LE.1.0-00137-STD.PROD-1",
     "firmwareid": "qcs8300-ride"
+  },
+  "sm8750-mtp": {
+    "machine": "sm8750-mtp",
+    "firmware": "",
+    "lavaname": "sm8750-mtp",
+    "target": "sm8750-mtp",
+    "buildid": "",
+    "firmwareid": ""
   }
 }


### PR DESCRIPTION
Enable tests for sm8750-mtp target in CI.

Depends-on: https://github.com/qualcomm-linux/job_render/pull/23 