### PR TITLE
Update final status in pre-merge as per build for kernel-topics

### DIFF
--- a/.github/workflows/pre_merge.yml
+++ b/.github/workflows/pre_merge.yml
@@ -91,7 +91,7 @@ jobs:
         uses: qualcomm-linux/kernel-config/.github/actions/workflow_status@main
         with:
           sha: ${{ inputs.sha }}
-          action_mode: ${{ needs.test.result }}
+          action_mode: ${{ needs.test.result != 'skipped' && needs.test.result || needs.build.result }}
           check_name: pre-merge
           repo: ${{ inputs.repo }}
           GH_TOKEN: ${{ secrets.PAT }}


### PR DESCRIPTION
This PR updates the workflow status based on conditions.
RCA:
The workflow status on the PR used to update the status as failed for topics repo as the LAVA tests are disabled for the topics.

Fix:
Lava tests are skipped for kernel-topics, therefore adding check to prevent workflow failure if these tests get skipped for topics repo.