### PR TITLE
ci : Check run event for Kernel checker

### DIFF
--- a/.github/actions/check_run/action.yml
+++ b/.github/actions/check_run/action.yml
@@ -20,7 +20,7 @@ inputs:
     required: true
   workflow_name:
     description: Workflow name to post check_run
-    required: false
+    required: true
 
 runs:
   using: "composite"
@@ -42,9 +42,24 @@ runs:
         ACCESS_TOKEN="${{ steps.app-token.outputs.token }}"
         s3_location="${{ inputs.s3_location }}"
         REPO="${{ inputs.repo }}"
-        post_name="Artifacts${{ inputs.workflow_name }} uploaded to S3"
+        workflow_name="${{ inputs.workflow_name }}"
 
-        echo "Creating check run for commit: $HEAD_SHA"
+        echo "Creating check run for workflow : $workflow_name and commit: $HEAD_SHA"
+
+        if [ "$workflow_name" = "pre_merge" ] || [ "$workflow_name" = "pre_merge_ubuntu" ] || [ "$workflow_name" = "pre_merge_yocto" ]; then
+          post_name="Artifacts for ${{ inputs.workflow_name }} uploaded to S3"
+          title="Check S3 Location"
+          text=$s3_location
+        elif [ "$workflow_name" = "Kernel Checkers" ]; then
+          post_name="Kernel Checkers passed"
+          echo "$post_name"
+          title="Kernel checker"
+          text=""
+        fi
+
+        echo "Post name : $post_name"
+        echo "Title : $title"
+
         CHECK_RUN_ID=$(curl -s -L -X POST \
           -H "Accept: application/vnd.github+json" \
           -H "Authorization: Bearer $ACCESS_TOKEN" \
@@ -55,16 +70,16 @@ runs:
             "head_sha": "'"$HEAD_SHA"'",
             "status": "in_progress",
             "output": {
-              "title": "Check S3 Location",
+              "title": "'"$title"'",
               "summary": "",
-              "text": "'"$s3_location"'"
+              "text": "'"$text"'"
             }
           }' | jq -r '.id')
 
-        if [ -z "$CHECK_RUN_ID" ]; then
-          echo "Failed to create check run. Exiting."
-          exit 1
-        fi
+          if [ -z "$CHECK_RUN_ID" ]; then
+            echo "Failed to create check run. Exiting."
+            exit 1
+          fi
 
         echo "Check run created with ID: $CHECK_RUN_ID"
 
@@ -80,10 +95,10 @@ runs:
             "status": "completed",
             "conclusion": "success",
             "output": {
-              "title": "Check S3 Location",
+              "title": "'"$title"'",
               "summary": "",
-              "text": "'"$s3_location"'"
+              "text": "'"$text"'"
             }
           }'
 
-        echo "Check run updated successfully."
+        echo "Check run updated successfully for $workflow_name"

--- a/.github/workflows/checker_override.yml
+++ b/.github/workflows/checker_override.yml
@@ -1,0 +1,87 @@
+name: Checker Override
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Pull request number
+        type: string
+        required: true
+      repo:
+        description: Target repository
+        type: string
+        required: true
+      reason:
+        description: Reason for override
+        type: string
+        required: true
+
+jobs:
+  extract-pr-metadata:
+    name: Extract PR Data
+    runs-on: ubuntu-latest
+    outputs:
+      pr_sha: ${{ steps.capture.outputs.pr_sha }}
+      pr_branch: ${{ steps.capture.outputs.pr_branch }}
+
+    steps:
+      - name: Capture PR metadata
+        id: capture
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = ${{ inputs.pr_number }};
+            const full = "${{ inputs.repo }}";
+            const [owner, repo] = full.split("/");
+
+            // Fetch PR details
+            const { data: pr } = await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number: prNumber,
+            });
+
+            const prSha = pr.head.sha;         // commit SHA of PR head
+            const prBranch = pr.base.ref;      // source branch name
+
+            core.setOutput('pr_sha', prSha);
+            core.setOutput('pr_branch', prBranch);
+
+      - name: Show values (for logs)
+        run: |
+          echo "PR number:  ${{ inputs.pr_number }}"
+          echo "PR SHA:     ${{ steps.capture.outputs.pr_sha }}"
+          echo "PR Branch:  ${{ steps.capture.outputs.pr_branch }}"
+
+  check_run:
+    runs-on: ubuntu-latest
+    needs: [extract-pr-metadata]
+    steps:
+      - name: Post check run
+        if: ${{ needs.extract-pr-metadata.outputs.pr_branch == 'qcom-6.18.y' }}
+        uses: qualcomm-linux/kernel-config/.github/actions/check_run@main
+        with:
+          sha: ${{ needs.extract-pr-metadata.outputs.pr_sha }}
+          repo: ${{ inputs.repo }}
+          APPID: ${{ secrets.APPID }}
+          PVK: ${{ secrets.PVK }}
+          workflow_name: "Kernel Checkers"
+
+      - name: Print Log
+        env:
+          PR_BRANCH: ${{ needs.extract-pr-metadata.outputs.pr_branch }}
+          TOKEN: ${{ secrets.PAT }}
+        run: |
+          if [ "$PR_BRANCH" = "qcom-6.18.y" ]; then
+            echo "Checker Override for branch qcom-6.18.y"
+
+            curl -L \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.PAT }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/${{ inputs.repo }}/issues/${{ inputs.pr_number }}/comments \
+            -d '{"body":"Kernel Checker override by ${{ github.actor }} for SHA : ${{  needs.extract-pr-metadata.outputs.pr_sha }}\n Reason: ${{ inputs.reason }}"}'
+
+          else
+            echo "Branch not applicable for override.."
+          fi

--- a/.github/workflows/kernel_checker.yml
+++ b/.github/workflows/kernel_checker.yml
@@ -82,7 +82,21 @@ jobs:
         check: [check-patch-compliance, check-uapi-headers, sparse-check, checkpatch,
           dt-binding-check, dtb-check]
       fail-fast: false
-  
+
+  check_run:
+    if: inputs.ref == 'qcom-6.18.y'
+    runs-on: ubuntu-latest
+    needs: [checker]
+    steps:
+      - name: Post check run
+        uses: qualcomm-linux/kernel-config/.github/actions/check_run@main
+        with:
+          sha: ${{ inputs.sha }}
+          repo: ${{ inputs.repo }}
+          APPID: ${{ secrets.APPID }}
+          PVK: ${{ secrets.PVK }}
+          workflow_name: "${{ github.workflow }}"
+
   final-status:
     runs-on: ubuntu-latest
     needs: [checker]

--- a/.github/workflows/pre-merge-ubuntu.yml
+++ b/.github/workflows/pre-merge-ubuntu.yml
@@ -103,7 +103,7 @@ jobs:
           sha: ${{ inputs.sha }}
           repo: ${{ inputs.repo }}
           s3_location: ${{ needs.generate_debians.outputs.artifacts_location }}
-          workflow_name: " for ${{ github.workflow }}"
+          workflow_name: "${{ github.workflow }}"
           APPID: ${{ secrets.APPID }}
           PVK: ${{ secrets.PVK }}
 

--- a/.github/workflows/pre-merge-yocto.yml
+++ b/.github/workflows/pre-merge-yocto.yml
@@ -78,7 +78,7 @@ jobs:
           sha: ${{ inputs.sha }}
           repo: ${{ inputs.repo }}
           s3_location: ${{ needs.build_yocto.outputs.artifacts_location }}
-          workflow_name: " for ${{ github.workflow }}"
+          workflow_name: "${{ github.workflow }}"
           APPID: ${{ secrets.APPID }}
           PVK: ${{ secrets.PVK }}
 


### PR DESCRIPTION
As part of QLI 2.0 Kernel CI/CD below should be flow :

1. Dev raises PR
2. Kernel checker is triggered
3.If kernel checker is passed, and maintainer approves PR then, Kernel CI/CD i.e sync, build test should trigger
4.If kernel checker fails, developer should fix the issue and repush the PR which will trigger kernel checker again

To achieve this, post a check run event for kernel checker in pass case for QLI 2.0 branch.
Based on check run event and approvals Kernel CI/CD will be triggered from Coral

Also introduce a workflow which will help override the kernel-checker in case of False positive