### PR TITLE
ci(fix): aws configure using CLI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,8 +107,11 @@ jobs:
           done
 
       - name: Configure AWS
-        uses: aws-actions/configure-aws-credentials@v2
-        with:
+        run: |
+          aws configure set aws_access_key_id $aws_access_key_id && \
+          aws configure set aws_secret_access_key $aws_secret_access_key && \
+          aws configure set default.region $aws-region
+       env:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-west-2


### PR DESCRIPTION
Remove aws-configure-credentials action as it has been blocked by org.