### PR TITLE
ci: Fix typo in aws variable name

### DIFF
--- a/.github/actions/build_ubuntu/action.yml
+++ b/.github/actions/build_ubuntu/action.yml
@@ -68,13 +68,13 @@ runs:
 
     - name: Configure AWS
       run: |
-        aws configure set aws_access_key_id "$aws-access-key-id" && \
-        aws configure set aws_secret_access_key "$aws-secret-access-key" && \
-        aws configure set default.region "$aws-region"
+        aws configure set aws_access_key_id "$AWS_ACCESS_KEY_ID" && \
+        aws configure set aws_secret_access_key "$AWS_SECRET_ACCESS_KEY" && \
+        aws configure set default.region "$AWS_REGION"
       env:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        aws-region: us-west-2
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        AWS_REGION: us-west-2
 
     - name: Sync kernel codebase
       shell: bash

--- a/.github/actions/build_yocto/action.yml
+++ b/.github/actions/build_yocto/action.yml
@@ -69,13 +69,13 @@ runs:
 
     - name: Configure AWS
       run: |
-        aws configure set aws_access_key_id "$aws-access-key-id" && \
-        aws configure set aws_secret_access_key "$aws-secret-access-key" && \
-        aws configure set default.region "$aws-region"
+        aws configure set aws_access_key_id "$AWS_ACCESS_KEY_ID" && \
+        aws configure set aws_secret_access_key "$AWS_SECRET_ACCESS_KEY" && \
+        aws configure set default.region "$AWS_REGION"
       env:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        aws-region: us-west-2
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        AWS_REGION: us-west-2
 
     - name: Set Kernel Version
       shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -108,13 +108,13 @@ jobs:
 
       - name: Configure AWS
         run: |
-          aws configure set aws_access_key_id "$aws-access-key-id" && \
-          aws configure set aws_secret_access_key "$aws-secret-access-key" && \
-          aws configure set default.region "$aws-region"
+          aws configure set aws_access_key_id "$AWS_ACCESS_KEY_ID" && \
+          aws configure set aws_secret_access_key "$AWS_SECRET_ACCESS_KEY" && \
+          aws configure set default.region "$AWS_REGION"
         env:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-west-2
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: us-west-2
 
       - name: Upload artifacts
         id: upload-artifacts


### PR DESCRIPTION
Fix typo in aws variable name
Replace hypen with underscore as hypes in not
recognized by shell as a variable name