### PR TITLE
ci : Add PR number to premerge run

### DIFF
--- a/.github/workflows/pre_merge.yml
+++ b/.github/workflows/pre_merge.yml
@@ -1,4 +1,5 @@
 name: pre_merge
+run-name: "${{ format('premerge: {0} - PR #{1}', inputs.repo, inputs.pr) }}"
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
As of now in actions only pre-merge is the run name, with this one cannot distinguis for which PR the workflow has ran, without actually going into workflow.

With this change PR number will be visible so that user can easily find the workflow run for a particular PR.