### PR TITLE
topic_maintainers: fix team slugs to use hyphens instead of dots

### DIFF
--- a/topic_maintainers.json
+++ b/topic_maintainers.json
@@ -36,168 +36,168 @@
         "qualcomm-kernel-maint"
     ],
     "tech/bsp/clk": [
-        "kernel.tech.bsp.clk.maint"
+        "kernel-tech-bsp-clk-maint"
     ],
     "tech/bsp/interconnect": [
-        "kernel.tech.bsp.interconnect.maint"
+        "kernel-tech-bsp-interconnect-maint"
     ],
     "tech/bsp/pinctrl": [
-        "kernel.tech.bsp.soc-infra.maint"
+        "kernel-tech-bsp-soc-infra-maint"
     ],
     "tech/bsp/remoteproc": [
-        "kernel.tech.bsp.soc-infra.maint"
+        "kernel-tech-bsp-soc-infra-maint"
     ],
     "tech/bsp/soc-infra": [
-        "kernel.tech.bsp.soc-infra.maint"
+        "kernel-tech-bsp-soc-infra-maint"
     ],
     "tech/bus/pci/all": [
-        "kernel.tech.bus.pci.maint"
+        "kernel-tech-bus-pci-maint"
     ],
     "tech/bus/pci/mhi": [
-        "kernel.tech.bus.pci.maint"
+        "kernel-tech-bus-pci-maint"
     ],
     "tech/bus/pci/phy": [
-        "kernel.tech.bus.pci.maint"
+        "kernel-tech-bus-pci-maint"
     ],
     "tech/bus/pci/pwrctl": [
-        "kernel.tech.bus.pci.pwrctl.maint"
+        "kernel-tech-bus-pci-pwrctl-maint"
     ],
     "tech/bus/peripherals": [
-        "kernel.tech.bus.peripherals.maint"
+        "kernel-tech-bus-peripherals-maint"
     ],
     "tech/bus/usb/dwc": [
-        "kernel.tech.bus.usb.maint"
+        "kernel-tech-bus-usb-maint"
     ],
     "tech/bus/usb/gadget": [
-        "kernel.tech.bus.usb.maint"
+        "kernel-tech-bus-usb-maint"
     ],
     "tech/bus/usb/phy": [
-        "kernel.tech.bus.usb.maint"
+        "kernel-tech-bus-usb-maint"
     ],
     "tech/debug/eud": [
-        "kernel.tech.debug.eud.maint"
+        "kernel-tech-debug-eud-maint"
     ],
     "tech/debug/hwtracing": [
-        "kernel.tech.debug.hwtracing.maint"
+        "kernel-tech-debug-hwtracing-maint"
     ],
     "tech/debug/rdbg": [
-        "kernel.tech.debug.rdbg.maint"
+        "kernel-tech-debug-rdbg-maint"
     ],
     "tech/debug/soc": [
-        "kernel.tech.debug.soc.maint"
+        "kernel-tech-debug-soc-maint"
     ],
     "tech/mem/dma-buf": [
-        "kernel.tech.mem.maint"
+        "kernel-tech-mem-maint"
     ],
     "tech/mem/iommu": [
-        "kernel.tech.mem.maint"
+        "kernel-tech-mem-maint"
     ],
     "tech/mem/secure-buffer": [
-        "kernel.tech.mem.maint"
+        "kernel-tech-mem-maint"
     ],
     "tech/mm/audio/all": [
-        "kernel.tech.mm.audio.maint"
+        "kernel-tech-mm-audio-maint"
     ],
     "tech/mm/audio/soundwire": [
-        "kernel.tech.mm.audio.maint"
+        "kernel-tech-mm-audio-maint"
     ],
     "tech/mm/camss": [
-        "kernel.tech.mm.camss.maint"
+        "kernel-tech-mm-camss-maint"
     ],
     "tech/mm/drm": [
-        "kernel.tech.mm.drm.maint"
+        "kernel-tech-mm-drm-maint"
     ],
     "tech/mm/fastrpc": [
-        "kernel.tech.mm.fastrpc.maint"
+        "kernel-tech-mm-fastrpc-maint"
     ],
     "tech/mm/gpu": [
-        "kernel.tech.mm.gpu.maint"
+        "kernel-tech-mm-gpu-maint"
     ],
     "tech/mm/phy": [
-        "kernel.tech.mm.phy.maint"
+        "kernel-tech-mm-phy-maint"
     ],
     "tech/mm/video": [
-        "kernel.tech.mm.video.maint"
+        "kernel-tech-mm-video-maint"
     ],
     "tech/mproc/all": [
-        "kernel.tech.mproc.maint"
+        "kernel-tech-mproc-maint"
     ],
     "tech/mproc/qmi": [
-        "kernel.tech.mproc.maint"
+        "kernel-tech-mproc-maint"
     ],
     "tech/mproc/rpmsg": [
-        "kernel.tech.mproc.maint"
+        "kernel-tech-mproc-maint"
     ],
     "tech/net/ath": [
-        "kernel.tech.net.ath.maint"
+        "kernel-tech-net-ath-maint"
     ],
     "tech/net/bluetooth": [
-        "kernel.tech.net.bluetooth.maint"
+        "kernel-tech-net-bluetooth-maint"
     ],
     "tech/net/eth": [
-        "kernel.tech.net.eth.maint"
+        "kernel-tech-net-eth-maint"
     ],
     "tech/net/phy": [
-        "kernel.tech.net.phy.maint"
+        "kernel-tech-net-phy-maint"
     ],
     "tech/net/qrtr": [
-        "kernel.tech.mproc.maint"
+        "kernel-tech-mproc-maint"
     ],
     "tech/net/rmnet": [
-        "kernel.tech.net.rmnet.maint"
+        "kernel-tech-net-rmnet-maint"
     ],
     "tech/overlay/dt": [
         "qualcomm-kernel-maint"
     ],
     "tech/pm/opp": [
-        "kernel.tech.pm.power.maint"
+        "kernel-tech-pm-power-maint"
     ],
     "tech/pm/pmdomain": [
-        "kernel.tech.pm.power.maint"
+        "kernel-tech-pm-power-maint"
     ],
     "tech/pm/power": [
-        "kernel.tech.pm.power.maint"
+        "kernel-tech-pm-power-maint"
     ],
     "tech/pm/thermal": [
-        "kernel.tech.pm.thermal.maint"
+        "kernel-tech-pm-thermal-maint"
     ],
     "tech/pmic/backlight": [
-        "kernel.tech.pmic.maint"
+        "kernel-tech-pmic-maint"
     ],
     "tech/pmic/mfd": [
-        "kernel.tech.pmic.maint"
+        "kernel-tech-pmic-maint"
     ],
     "tech/pmic/misc": [
-        "kernel.tech.pmic.maint"
+        "kernel-tech-pmic-maint"
     ],
     "tech/pmic/regulator": [
-        "kernel.tech.pmic.maint"
+        "kernel-tech-pmic-maint"
     ],
     "tech/pmic/supply": [
-        "kernel.tech.pmic.maint"
+        "kernel-tech-pmic-maint"
     ],
     "tech/security/crypto": [
-        "kernel.tech.security.crypto.maint"
+        "kernel-tech-security-crypto-maint"
     ],
     "tech/security/firmware-smc": [
-        "kernel.tech.security.firmware-smc.maint"
+        "kernel-tech-security-firmware-smc-maint"
     ],
     "tech/security/fscrypt": [
-        "kernel.tech.security.crypto.maint"
+        "kernel-tech-security-crypto-maint"
     ],
     "tech/security/ice": [
-        "kernel.tech.security.crypto.maint"
+        "kernel-tech-security-crypto-maint"
     ],
     "tech/storage/all": [
-        "kernel.tech.storage.maint"
+        "kernel-tech-storage-maint"
     ],
     "tech/storage/nvmem": [
-        "kernel.tech.storage.nvmem.maint"
+        "kernel-tech-storage-nvmem-maint"
     ],
     "tech/storage/phy": [
-        "kernel.tech.storage.maint"
+        "kernel-tech-storage-maint"
     ],
     "tech/virt/gunyah": [
-        "kernel.tech.virt.gunyah.maint"
+        "kernel-tech-virt-gunyah-maint"
     ]
 }


### PR DESCRIPTION
- Replace dot-separated team slugs with hyphen-separated equivalents
- Fixes add-reviewers workflow failure due to invalid team slug format
- GitHub team slugs are auto-converted to use hyphens in the URL/API,
  but the actual team name can use dots (e.g. kernel.checker.maint)
- The requestReviewers API requires the team slug (hyphenated), not
  the team name (dotted)