### PR TITLE
Revert "qcom-next.conf: add shikra topic branches"

### DIFF
--- a/qcom-next.conf
+++ b/qcom-next.conf
@@ -67,5 +67,3 @@ tech/all/workaround        https://github.com/qualcomm-linux/kernel-topics.git  
 tech/mproc/all        	   https://github.com/qualcomm-linux/kernel-topics.git       tech/mproc/all
 tech/noup/debug/all        https://github.com/qualcomm-linux/kernel-topics.git       tech/noup/debug/all
 tech/hwe/unoq              https://github.com/qualcomm-linux/kernel-topics.git       tech/hwe/unoq
-early/hwe/shikra/drivers   https://github.com/qualcomm-linux/kernel-topics.git       early/hwe/shikra/drivers
-early/hwe/shikra/dt        https://github.com/qualcomm-linux/kernel-topics.git       early/hwe/shikra/dt


### PR DESCRIPTION
Reverts qualcomm-linux/kernel-config#148

Development in progress, will enable once in proper shape