### PR TITLE
ci: Enable Kaanapali-mtp

### DIFF
--- a/ci/MACHINES.json
+++ b/ci/MACHINES.json
@@ -76,8 +76,8 @@
     "target": "kaanapali-mtp",
     "buildid": "",
     "firmwareid": "",
-    "rootfs": "",
-    "flash_type": "fastboot"
+    "rootfs": "kaanapali-mtp",
+    "flash_type": "qdl"
   },
   "x1e80100-crd": {
     "machine": "x1e80100-crd",


### PR DESCRIPTION
Enable kaanapali-mtp in Lava Tests
Use QDL way of flashing for kaanapali