### PR TITLE
qcom-next.conf: add optee topic branch

### DIFF
--- a/qcom-next.conf
+++ b/qcom-next.conf
@@ -48,6 +48,7 @@ tech/pm/thermal            https://github.com/qualcomm-linux/kernel-topics.git  
 tech/security/crypto       https://github.com/qualcomm-linux/kernel-topics.git       tech/security/crypto
 tech/security/fscrypt      https://github.com/qualcomm-linux/kernel-topics.git       tech/security/fscrypt
 tech/security/ice          https://github.com/qualcomm-linux/kernel-topics.git       tech/security/ice
+tech/security/optee        https://github.com/qualcomm-linux/kernel-topics.git       tech/security/optee
 tech/storage/nvmem         https://github.com/qualcomm-linux/kernel-topics.git       tech/storage/nvmem
 tech/storage/phy           https://github.com/qualcomm-linux/kernel-topics.git       tech/storage/phy
 tech/storage/all           https://github.com/qualcomm-linux/kernel-topics.git       tech/storage/all


### PR DESCRIPTION
Add OP-TEE topic branch to qcom-next.conf carrying in flight patches to enable OP-TEE based TZ services.