### PR TITLE
qcom-next.conf: add devfreq topic branch

### DIFF
--- a/qcom-next.conf
+++ b/qcom-next.conf
@@ -1,5 +1,6 @@
 baseline                   https://github.com/qualcomm-linux/kernel.git              qcom-next-staging
 tech/bsp/clk               https://github.com/qualcomm-linux/kernel-topics.git       tech/bsp/clk
+tech/bsp/devfreq           https://github.com/qualcomm-linux/kernel-topics.git       tech/bsp/devfreq
 tech/bsp/ec                https://github.com/qualcomm-linux/kernel-topics.git       tech/bsp/ec
 tech/bsp/interconnect      https://github.com/qualcomm-linux/kernel-topics.git       tech/bsp/interconnect
 tech/mem/secure-buffer     https://github.com/qualcomm-linux/kernel-topics.git       tech/mem/secure-buffer


### PR DESCRIPTION
Add devfreq, scmi drivers topic branch to qcom-next.conf.