### PR TITLE
Revert "ci: Update flash mode for qcs615-ride"

### DIFF
--- a/ci/MACHINES.json
+++ b/ci/MACHINES.json
@@ -67,7 +67,7 @@
     "buildid": "",
     "firmwareid": "qcs615-ride",
     "rootfs": "qcs615-ride",
-    "flash_type": "fastboot"
+    "flash_type": "qdl"
   },
   "kaanapali-mtp": {
     "machine": "kaanapali-mtp",


### PR DESCRIPTION
Move back to QDL way of loading.

This reverts commit e6e37adce824c9e4557e08a3ef681b7876d836d1.