### PR TITLE
ci: Fix LAVA test filter to exclude suite-level result row

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -183,7 +183,7 @@ jobs:
 
           jq '
             (if type=="object" and .results then .results else . end)
-              | map(select(.metadata | tostring | contains("0_qcom-next-ci-premerge-tests")))
+              | map(select(.metadata | tostring | startswith("definition: 0_qcom-next-ci-premerge-tests")))
               | map(select(.result == "pass" or .result == "fail" or .result == "skip" or .result == "error"))
               | map({
                       name: .name,


### PR DESCRIPTION
The previous filter used contains("0_qcom-next-ci-premerge-tests") which matched both the individual test cases (from the 0_qcom-next-ci-premerge-tests suite) and the suite-level summary entry (from the lava suite, with metadata 'case: 0_qcom-next-ci-premerge-tests'). This caused a spurious '0_qcom-next-ci-premerge-tests' row to appear in the test results table.

Switch to startswith("definition: 0_qcom-next-ci-premerge-tests") so only test cases whose metadata begins with that prefix are selected. The suite-level summary entry has metadata starting with 'definition: lava' and is therefore correctly excluded.