### PR TITLE
Revert "Revert "qcom-next.conf: add shikra topic branches""

### DIFF
--- a/qcom-next.conf
+++ b/qcom-next.conf
@@ -69,3 +69,5 @@ tech/all/workaround        https://github.com/qualcomm-linux/kernel-topics.git  
 tech/mproc/all        	   https://github.com/qualcomm-linux/kernel-topics.git       tech/mproc/all
 tech/noup/debug/all        https://github.com/qualcomm-linux/kernel-topics.git       tech/noup/debug/all
 tech/hwe/unoq              https://github.com/qualcomm-linux/kernel-topics.git       tech/hwe/unoq
+early/hwe/shikra/drivers   https://github.com/qualcomm-linux/kernel-topics.git       early/hwe/shikra/drivers
+early/hwe/shikra/dt        https://github.com/qualcomm-linux/kernel-topics.git       early/hwe/shikra/dt


### PR DESCRIPTION
Enable back shikra topic branches.

This reverts commit b88fb4b558fdb424df749e2b49faaac5175dc38e.