### PR TITLE
ci: Filter test targets by branch using per-target branches list

### DIFF
--- a/.github/actions/loading/action.yml
+++ b/.github/actions/loading/action.yml
@@ -2,6 +2,12 @@
 name: Load Parameters
 description: Load parameters for the build job
 
+inputs:
+  branch:
+    description: Target branch used to filter test targets
+    required: false
+    default: ""
+
 outputs:
   build_matrix:
     description: Build matrix
@@ -29,6 +35,8 @@ runs:
     - name: Set Build Matrix
       id: set-matrix
       uses: actions/github-script@v7
+      env:
+        INPUT_BRANCH: ${{ inputs.branch }}
       with:
         script: |
           const fs = require('fs');
@@ -65,8 +73,10 @@ runs:
           console.log("Boot Bins:", bootbins);
 
           // rootfs matrix: machine, rootfs
+          const branch = process.env.INPUT_BRANCH || "";
           const rootfs_matrix = Object.values(targets)
-            .filter(({ rootfs }) => rootfs && rootfs.trim() !== '') // filter out empty or null in case Yocto Build is not enabled on a target
+            .filter(({ rootfs }) => rootfs && rootfs.trim() !== '')
+            .filter(({ branches }) => !branch || !branches || branches.includes(branch))
             .map(({ machine, rootfs, firmwareid, lavaname, flash_type }) => ({ machine, rootfs, firmwareid, lavaname, flash_type }));
           core.setOutput('rootfs_matrix', JSON.stringify(rootfs_matrix));
           console.log("Rootfs Matrix:", rootfs_matrix);

--- a/.github/workflows/loading.yml
+++ b/.github/workflows/loading.yml
@@ -4,6 +4,12 @@ description: Load required parameters for the subsequent jobs
 
 on:
   workflow_call:
+    inputs:
+      branch:
+        description: Target branch used to filter test targets
+        type: string
+        required: false
+        default: ""
     outputs:
       build_matrix:
         description: Build matrix
@@ -43,3 +49,5 @@ jobs:
       - name: Load Parameters
         id: loading
         uses: qualcomm-linux/kernel-config/.github/actions/loading@main
+        with:
+          branch: ${{ inputs.branch }}

--- a/.github/workflows/pre_merge.yml
+++ b/.github/workflows/pre_merge.yml
@@ -37,6 +37,8 @@ jobs:
     needs: [init-status]
     uses: qualcomm-linux/kernel-config/.github/workflows/loading.yml@main
     secrets: inherit
+    with:
+      branch: ${{ inputs.ref }}
 
   build:
     needs: [loading, init-status]

--- a/ci/MACHINES.json
+++ b/ci/MACHINES.json
@@ -7,7 +7,8 @@
     "buildid": "QCM6490.LE.1.0-00376-STD.PROD-1",
     "firmwareid": "rb3gen2",
     "rootfs": "rb3gen2-core-kit",
-    "flash_type": "qdl"
+    "flash_type": "qdl",
+    "branches": ["qcom-next-staging", "qcom-6.18.y"]
   },
   "qcs9100-ride-r3": {
     "machine": "qcs9100-ride-r3",
@@ -17,7 +18,8 @@
     "buildid": "QCS9100.LE.1.0-00243-STD.PROD-1",
     "firmwareid": "sa8775p-ride",
     "rootfs": "qcs9100-ride-sx",
-    "flash_type": "qdl"
+    "flash_type": "qdl",
+    "branches": ["qcom-next-staging", "qcom-6.18.y"]
   },
   "qcs8300-ride": {
     "machine": "qcs8300-ride",
@@ -27,7 +29,8 @@
     "buildid": "QCS8300.LE.1.0-00137-STD.PROD-1",
     "firmwareid": "qcs8300-ride",
     "rootfs": "qcs8300-ride-sx",
-    "flash_type": "qdl"
+    "flash_type": "qdl",
+    "branches": ["qcom-next-staging", "qcom-6.18.y"]
   },
   "sm8750-mtp": {
     "machine": "sm8750-mtp",
@@ -37,7 +40,8 @@
     "buildid": "",
     "firmwareid": "sm8750-mtp",
     "rootfs": "sm8750-mtp",
-    "flash_type": "qdl"
+    "flash_type": "qdl",
+    "branches": ["qcom-next-staging"]
   },
   "lemans-evk": {
     "machine": "lemans-evk",
@@ -47,7 +51,8 @@
     "buildid": "QCS9100.LE.1.0-00243-STD.PROD-1",
     "firmwareid": "sa8775p-ride",
     "rootfs": "iq-9075-evk",
-    "flash_type": "qdl"
+    "flash_type": "qdl",
+    "branches": ["qcom-next-staging", "qcom-6.18.y"]
   },
   "monaco-evk": {
     "machine": "monaco-evk",
@@ -57,7 +62,8 @@
     "buildid": "QCS8300.LE.1.0-00137-STD.PROD-1",
     "firmwareid": "qcs8300-ride",
     "rootfs": "iq-8275-evk",
-    "flash_type": "fastboot"
+    "flash_type": "fastboot",
+    "branches": ["qcom-next-staging", "qcom-6.18.y"]
   },
   "qcs615-adp-air": {
     "machine": "qcs615-ride",
@@ -67,7 +73,8 @@
     "buildid": "",
     "firmwareid": "qcs615-ride",
     "rootfs": "qcs615-ride",
-    "flash_type": "qdl"
+    "flash_type": "qdl",
+    "branches": ["qcom-next-staging", "qcom-6.18.y"]
   },
   "kaanapali-mtp": {
     "machine": "kaanapali-mtp",
@@ -77,7 +84,8 @@
     "buildid": "",
     "firmwareid": "kaanapali-mtp",
     "rootfs": "kaanapali-mtp",
-    "flash_type": "qdl"
+    "flash_type": "qdl",
+    "branches": ["qcom-next-staging"]
   },
   "x1e80100-crd": {
     "machine": "x1e80100-crd",
@@ -87,7 +95,8 @@
     "buildid": "",
     "firmwareid": "",
     "rootfs": "iq-x7181-evk",
-    "flash_type": "fastboot"
+    "flash_type": "fastboot",
+    "branches": ["qcom-next-staging", "qcom-6.18.y"]
   },
   "glymur-crd": {
     "machine": "glymur-crd",
@@ -97,6 +106,7 @@
     "buildid": "",
     "firmwareid": "glymur-crd",
     "rootfs": "glymur-crd",
-    "flash_type": "qdl"
+    "flash_type": "qdl",
+    "branches": ["qcom-next-staging"]
   }
 }


### PR DESCRIPTION
Add a 'branches' field to each entry in ci/MACHINES.json that lists the branches for which pre-merge tests should run on that target. Targets without a matching branch are excluded from the rootfs_matrix and therefore skipped during the test job.

Examples:
  - lemans-evk: ["qcom-next-staging", "qcom-6.18.y"]
  - glymur-crd:  ["qcom-next-staging"]