### PR TITLE
ci: Add run-name with PR number to kernel_checker workflow

### DIFF
--- a/.github/workflows/kernel_checker.yml
+++ b/.github/workflows/kernel_checker.yml
@@ -1,4 +1,5 @@
 name: Kernel Checkers
+run-name: "${{ format('kernel-checker: {0} - PR #{1}', inputs.repo, inputs.pr) }}"
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Add a run-name to kernel_checker.yml so the workflow run is labelled with the repo and PR number in the GitHub Actions UI.

  kernel-checker: <repo> - PR #<number>