### PR TITLE
ci: Filter LAVA results by suite id instead of metadata string

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -177,13 +177,18 @@ jobs:
 
           mkdir -p lava-results
 
-          curl -s "https://lava-oss.qualcomm.com/api/v0.2/jobs/$JOB_ID/tests/" > results.json
+          curl -s "https://lava-oss.qualcomm.com/api/v0.2/jobs/$JOB_ID/tests/?limit=500" > results.json
           echo "Downloaded results to results.json"
           jq '.[0] ? // . | length' results.json || true
 
-          jq '
+          # Determine the suite id for the premerge test suite (anything that is not 'lava')
+          SUITE_ID=$(curl -s "https://lava-oss.qualcomm.com/api/v0.2/jobs/$JOB_ID/suites/" \
+            | jq -r '.results[] | select(.name != "lava") | .id')
+          echo "Premerge suite id: $SUITE_ID"
+
+          jq --argjson suite_id "${SUITE_ID}" '
             (if type=="object" and .results then .results else . end)
-              | map(select(.metadata | tostring | startswith("definition: 0_qcom-next-ci-premerge-tests")))
+              | map(select(.suite == $suite_id))
               | map(select(.result == "pass" or .result == "fail" or .result == "skip" or .result == "error"))
               | map({
                       name: .name,


### PR DESCRIPTION
The previous filter relied on the metadata field starting with 'definition: 0_qcom-next-ci-premerge-tests'. This broke for LAVA job 97482 (qcs615-ride, PR #582) where the LAVA server stored a truncated suite name '0_qcom-nex[' causing both the suite name and metadata fields to be corrupted, producing an empty Tests-qcs615-ride.json and no results in the PR comment.

Fix by fetching the suite list from the LAVA suites API and filtering tests by suite id (the numeric foreign key) instead of the metadata string. The premerge suite is identified as any suite whose name is not 'lava' — this is robust to any truncation or naming variation of the suite name on the LAVA server side.