### PR TITLE
ci: Enable Yocto test job in post-merge workflow

### DIFF
--- a/.github/actions/lava_job_render/action.yml
+++ b/.github/actions/lava_job_render/action.yml
@@ -121,10 +121,15 @@ runs:
       shell: bash
       env:
         FLASH_TYPE: ${{ inputs.flash_type }}
+        BUILD_TYPE: ${{ inputs.build_type }}
       run: |
         flash_type="${FLASH_TYPE:-qdl}"
         flash_type="$(echo "$flash_type" | tr '[:upper:]' '[:lower:]')"
         echo "Flash type: $flash_type"
+
+        build_type="${BUILD_TYPE:-yocto}"
+        build_type="$(echo "$build_type" | tr '[:upper:]' '[:lower:]')"
+        echo "Build type: $build_type"
 
         major=$(echo "${{ inputs.kernel_version }}" | cut -d. -f1)
         patchlevel=$(echo "${{ inputs.kernel_version }}" | cut -d. -f2 | cut -d- -f1)
@@ -250,12 +255,12 @@ runs:
         elif [[ "$flash_type" == "qdl" ]]; then
           EXTRA_ARGS=""
           if [[ "${{ inputs.build_type }}" == "yocto" ]]; then
-            EXTRA_ARGS="--meta-qcom"
+            EXTRA_ARGS="--meta-qcom_PreMerge --meta-qcom"
           fi
           export TARGET="${{ env.LAVA_NAME }}"
           export TARGET_DTB="${{ env.MACHINE }}"
           export BOOT_METHOD=flasher
           echo "QDL target $TARGET"
           echo "QDL target DTB $TARGET_DTB"
-          python3 lava_Job_definition_generator.py --localjson ./data/cloudData.json --qcom-next-ci-premerge ${EXTRA_ARGS}
+          python3 lava_Job_definition_generator.py --localjson ./data/cloudData.json ${EXTRA_ARGS}
         fi

--- a/.github/workflows/post-merge-yocto.yml
+++ b/.github/workflows/post-merge-yocto.yml
@@ -44,6 +44,7 @@ jobs:
     steps:
       - name: Update Summary
         run: |
+          echo "SHA : ${{ inputs.ref }}"
           echo "## Yocto Build Generation" >> $GITHUB_STEP_SUMMARY
           echo "- Pull Request Number: \`${{ inputs.pr || 'Nightly Build on Tip' }}\`" >> $GITHUB_STEP_SUMMARY
           echo "- Head Commit SHA: \`${{ inputs.sha || 'N/A' }}\`" >> $GITHUB_STEP_SUMMARY
@@ -56,6 +57,8 @@ jobs:
     needs: init-status
     uses: qualcomm-linux/kernel-config/.github/workflows/loading.yml@main
     secrets: inherit
+    with:
+      branch: ${{ inputs.ref }}
 
   build_yocto:
     name: Build Yocto
@@ -83,11 +86,25 @@ jobs:
           APPID: ${{ secrets.APPID }}
           PVK: ${{ secrets.PVK }}
 
+  test:
+    needs: [init-status, loading, build_yocto]
+    uses: qualcomm-linux-stg/kernel-config/.github/workflows/test.yml@main
+    secrets: inherit
+    with:
+      docker_image: kmake-image:ver.1.0
+      rootfs_matrix: ${{ needs.loading.outputs.rootfs_matrix }}
+      kernel_version: "6.18"
+      commit_SHA: ${{ inputs.sha }}
+      branch: ${{ inputs.ref }}
+      pr_number: "tip"
+      flash_type: "qdl"
+      build_type: "yocto"
+
   final-status:
     name: Finalize Status
     if: always()
     runs-on: ubuntu-latest
-    needs: [build_yocto, check_run]
+    needs: [build_yocto, check_run, test]
     steps:
       - name: Set final status
         uses: qualcomm-linux/kernel-config/.github/actions/workflow_status@main


### PR DESCRIPTION
Add a 'test' job to post-merge-yocto.yml that invokes the test workflow with Yocto-specific parameters (build_type, flash_type, rootfs_matrix, kernel_version).

Pass lava playlist as --meta-qcom_PreMerge to trigger tests