### PR TITLE
ci: Fix missing test block for qdl+kbdev LAVA jobs

### DIFF
--- a/.github/actions/lava_job_render/action.yml
+++ b/.github/actions/lava_job_render/action.yml
@@ -256,6 +256,8 @@ runs:
           EXTRA_ARGS=""
           if [[ "${{ inputs.build_type }}" == "yocto" ]]; then
             EXTRA_ARGS="--meta-qcom_PreMerge --meta-qcom"
+          else
+            EXTRA_ARGS="--qcom-next-ci-premerge"
           fi
           export TARGET="${{ env.LAVA_NAME }}"
           export TARGET_DTB="${{ env.MACHINE }}"


### PR DESCRIPTION
For flash_type=qdl with build_type=kbdev, the EXTRA_ARGS variable was left empty, causing lava_Job_definition_generator.py to generate a LAVA job definition without a test: section. This meant no tests were ever scheduled on the device.

Add --qcom-next-ci-premerge for the qdl+kbdev path, consistent with the fastboot path. The yocto path retains its own flags (--meta-qcom_PreMerge --meta-qcom).