### PR TITLE
Revert "qcom-next.conf: add optee topic branch"

### DIFF
--- a/qcom-next.conf
+++ b/qcom-next.conf
@@ -50,7 +50,6 @@ tech/pm/thermal            https://github.com/qualcomm-linux/kernel-topics.git  
 tech/security/crypto       https://github.com/qualcomm-linux/kernel-topics.git       tech/security/crypto
 tech/security/fscrypt      https://github.com/qualcomm-linux/kernel-topics.git       tech/security/fscrypt
 tech/security/ice          https://github.com/qualcomm-linux/kernel-topics.git       tech/security/ice
-tech/security/optee        https://github.com/qualcomm-linux/kernel-topics.git       tech/security/optee
 tech/storage/nvmem         https://github.com/qualcomm-linux/kernel-topics.git       tech/storage/nvmem
 tech/storage/phy           https://github.com/qualcomm-linux/kernel-topics.git       tech/storage/phy
 tech/storage/all           https://github.com/qualcomm-linux/kernel-topics.git       tech/storage/all


### PR DESCRIPTION
Changes in optee branch needs to be validated first. Enable post validation.

This reverts commit 1056bf2f106aa93075a762f61a58990d89ec941b.