### PR TITLE
ci: Derive kernel version for Yocto Builds

### DIFF
--- a/.github/actions/build_yocto/action.yml
+++ b/.github/actions/build_yocto/action.yml
@@ -37,6 +37,9 @@ outputs:
   artifacts_location:
     value: ${{ steps.upload_artifacts.outputs.s3_location }}
     description: Aws location
+  kernel_version:
+    value: ${{ steps.get_version.outputs.kernel_version }}
+    description: Kernel version built
 
 runs:
   using: 'composite'
@@ -163,6 +166,21 @@ runs:
         CI_YAML_DIR=$KAS_WORK_DIR/meta-qcom/ci
         cp kernel-override.yml $CI_YAML_DIR
         $KAS_CONTAINER build $CI_YAML_DIR/${{ env.rootfs }}.yml:$CI_YAML_DIR/${{ inputs.kernel_yaml }}.yml:$CI_YAML_DIR/qcom-distro.yml:$CI_YAML_DIR/kernel-override.yml:$CI_YAML_DIR/lock.yml
+        if [[ "$kernel_ver" == "6.18" ]]; then
+          recipe="linux-qcom"
+        else
+          recipe="linux-qcom-next"
+        fi
+        raw_ver=$($KAS_CONTAINER shell $CI_YAML_DIR/${{ env.rootfs }}.yml:$CI_YAML_DIR/${{ inputs.kernel_yaml }}.yml:$CI_YAML_DIR/qcom-distro.yml:$CI_YAML_DIR/kernel-override.yml:$CI_YAML_DIR/lock.yml -c "bitbake -e $recipe | grep '^KERNEL_VERSION='" | cut -d'"' -f2)
+        echo "raw_kernel_version=$raw_ver" >> $GITHUB_ENV
+
+    - name: Get Kernel Version
+      id: get_version
+      shell: bash
+      run: |
+        version=$(echo "${{ env.raw_kernel_version }}" | sed 's/-g[0-9a-f][0-9a-f]*.*//; s/-dirty//')
+        echo "Kernel version: $version"
+        echo "kernel_version=$version" >> $GITHUB_OUTPUT
 
     - name: Prepare file list for log upload
       if: always()

--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -29,6 +29,9 @@ on:
       artifacts_location:
         description: 'Artifacts Upload location'
         value: ${{ jobs.compile_yocto.outputs.artifacts_location }}
+      kernel_version:
+        description: "Kernel version built"
+        value: ${{ jobs.compile_yocto.outputs.kernel_version }}
 
 env:
   CACHE_DIR: /efs/kernel/meta-qcom
@@ -76,6 +79,7 @@ jobs:
     outputs:
       artifacts_location: ${{ steps.build_yocto.outputs.artifacts_location }}
       workspace_path: ${{ steps.sync.outputs.workspace_path }}
+      kernel_version: ${{ steps.build_yocto.outputs.kernel_version }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/post-merge-yocto.yml
+++ b/.github/workflows/post-merge-yocto.yml
@@ -93,7 +93,7 @@ jobs:
     with:
       docker_image: kmake-image:ver.1.0
       rootfs_matrix: ${{ needs.loading.outputs.rootfs_matrix }}
-      kernel_version: "6.18"
+      kernel_version: ${{ needs.build_yocto.outputs.kernel_version }}
       commit_SHA: ${{ inputs.sha }}
       branch: ${{ inputs.ref }}
       pr_number: "tip"

--- a/.github/workflows/post-merge-yocto.yml
+++ b/.github/workflows/post-merge-yocto.yml
@@ -100,6 +100,114 @@ jobs:
       flash_type: "qdl"
       build_type: "yocto"
 
+
+  nightly_report:
+    name: Nightly Test Report
+    if: always()
+    needs: [test]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download all test JSON artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: Tests-*
+          path: all-json
+          merge-multiple: true
+
+      - name: Download all job info artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: job_info_*
+          path: job-info
+          merge-multiple: true
+
+      - name: Generate report
+        run: |
+          set -e
+          INPUT_DIR="all-json"
+
+          sha="${{ inputs.sha }}"
+          short_sha="${sha:0:7}"
+          commit_url="https://github.com/${{ inputs.repo }}/commit/${sha}"
+          run_url="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+          {
+            echo "# Nightly LAVA Test Report"
+            echo ""
+            echo "| | |"
+            echo "| --- | --- |"
+            echo "| **Branch** | \`${{ inputs.ref }}\` |"
+            echo "| **Commit** | [\`${short_sha}\`](${commit_url}) |"
+            echo "| **Run** | [${run_url}](${run_url}) |"
+            echo ""
+
+            if ls job-info/*.md 1>/dev/null 2>&1; then
+              echo "## LAVA Jobs"
+              cat job-info/*.md
+              echo ""
+            fi
+
+            mapfile -t FILES < <(ls "$INPUT_DIR"/*.json 2>/dev/null || true)
+            if [ ${#FILES[@]} -gt 0 ]; then
+              echo "## Test Matrix"
+              echo ""
+
+              TARGETS=()
+              for f in "${FILES[@]}"; do
+                TARGETS+=("$(basename "$f" .json | sed 's/^Tests-//')")
+              done
+
+              TESTS=$(jq -r '.[].name' "${FILES[@]}" | sort -u)
+
+              printf "| Test Case "
+              for t in "${TARGETS[@]}"; do printf "| %s " "$t"; done
+              printf "|
+"
+
+              printf "| --- "
+              for _ in "${TARGETS[@]}"; do printf "| :---: "; done
+              printf "|
+"
+
+              while IFS= read -r test; do
+                printf "| %s " "$test"
+                for t in "${TARGETS[@]}"; do
+                  res=$(jq -r --arg n "$test" '.[] | select(.name==$n) | .result'                     "$INPUT_DIR/Tests-${t}.json" 2>/dev/null || true)
+                  case "$res" in
+                    pass)  cell="✅" ;;
+                    fail)  cell="❌" ;;
+                    skip)  cell="⚠️" ;;
+                    error) cell="⛔" ;;
+                    *)     cell="➖" ;;
+                  esac
+                  printf "| %s " "$cell"
+                done
+                printf "|
+"
+              done <<< "$TESTS"
+
+              echo ""
+              echo "## Summary"
+              echo ""
+              printf "| Target | ✅ Pass | ❌ Fail | ⚠️ Skip | Total |
+"
+              printf "| --- | :---: | :---: | :---: | :---: |
+"
+              for t in "${TARGETS[@]}"; do
+                f="$INPUT_DIR/Tests-${t}.json"
+                total=$(jq 'length' "$f")
+                if [ "$total" -eq 0 ]; then
+                  printf "| %s | ➖ | ➖ | ➖ | N/A (Incomplete) |\n" "$t"
+                else
+                  pass=$(jq '[.[] | select(.result=="pass")] | length' "$f")
+                  fail=$(jq '[.[] | select(.result=="fail")] | length' "$f")
+                  skip=$(jq '[.[] | select(.result=="skip")] | length' "$f")
+                  printf "| %s | %s | %s | %s | %s |\n" "$t" "$pass" "$fail" "$skip" "$total"
+                fi
+              done
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
   final-status:
     name: Finalize Status
     if: always()


### PR DESCRIPTION
Instead of hardcoding the kernel version (e.g. "6.18") in the post-merge Yocto workflow, extract it from the Yocto Build.

Changes:
- build_yocto/action.yml: add Get Kernel Version step reading from Yocto build.
- build-yocto.yml: bubble kernel_version output from compile_yocto job up to the workflow-level outputs
- post-merge-yocto.yml: replace hardcoded "6.18" with needs.build_yocto.outputs.kernel_version