### PR TITLE
ci: Fix integer expression error in nightly_report summary

### DIFF
--- a/.github/workflows/post-merge-yocto.yml
+++ b/.github/workflows/post-merge-yocto.yml
@@ -190,7 +190,8 @@ jobs:
               printf "| --- | :---: | :---: | :---: | :---: |\n"
               for t in "${TARGETS[@]}"; do
                 f="$INPUT_DIR/Tests-${t}.json"
-                total=$(jq 'length' "$f")
+                total=$(jq 'length' "$f" 2>/dev/null || echo 0)
+                total="${total:-0}"
                 if [ "$total" -eq 0 ]; then
                   printf "| %s | ➖ | ➖ | ➖ | N/A (Incomplete) |\n" "$t"
                 else


### PR DESCRIPTION
jq 'length' can return empty output if the JSON file is malformed or the jq call fails, causing '[ "$total" -eq 0 ]' to error with 'integer expression expected' and abort the report generation.

Guard with '|| echo 0' and '${total:-0}' so the comparison always has a valid integer regardless of jq output.
