### PR TITLE
Update URL from which ubtuntu docker needs to be pulled

### DIFF
--- a/.github/workflows/ubuntu-package-generation.yml
+++ b/.github/workflows/ubuntu-package-generation.yml
@@ -63,7 +63,7 @@ jobs:
           target: ${{ matrix.ubuntu_matrix.target }}
           efi: ${{ matrix.ubuntu_matrix.efi }}
           firmware: ${{ matrix.ubuntu_matrix.firmware }}
-          docker_image: ${{ vars.TECH_TEAM_NAMESPACE }}/kmake-image-ubuntu-noble-arm64:${{ vars.KMAKE_UBUNTU_IMAGE_VERSION }}
+          docker_image: kmake-image-ubuntu-noble-arm64:${{ vars.KMAKE_UBUNTU_IMAGE_VERSION }}
         env:
           token: ${{ secrets.PAT }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
The ubuntu's kmake image is still being fetched from code Linaro rather than AWS ECR. Due to this tech_team_namespace variable should not be involved in url from which the docker pull is done