### PR TITLE
Fix for Pre-merge of qualcomm-linux/video-driver failing

### DIFF
--- a/.github/actions/pull_docker_image/action.yml
+++ b/.github/actions/pull_docker_image/action.yml
@@ -8,7 +8,9 @@ inputs:
 
   registry:
     description: "Registry to pull from. E.g. '<account>.dkr.ecr.<region>.amazonaws.com' or 'artifacts.codelinaro.org/clo-420-qli-registry'"
-    required: true
+    required: false
+    default: "artifacts.codelinaro.org/clo-420-qli-registry"
+
 
 runs:
   using: "composite"


### PR DESCRIPTION
Supporting backward compatibility for pull docker image action so that other repositories using this action wont fail