### PR TITLE
ci: build_yocto: fix meta-qcom clone path in tip mode

### DIFF
--- a/.github/actions/build_yocto/action.yml
+++ b/.github/actions/build_yocto/action.yml
@@ -171,8 +171,8 @@ runs:
             meta_qcom_ref="master"
           fi
 
-          git clone https://github.com/qualcomm-linux/meta-qcom.git -b $meta_qcom_ref
-          meta_qcom_sha=$(git -C meta-qcom rev-parse HEAD)
+          git clone https://github.com/qualcomm-linux/meta-qcom.git -b $meta_qcom_ref "$KAS_WORK_DIR/meta-qcom"
+          meta_qcom_sha=$(git -C "$KAS_WORK_DIR/meta-qcom" rev-parse HEAD)
           echo $meta_qcom_sha > build_id.txt
           cat build_id.txt
           cat kernel-override.yml


### PR DESCRIPTION
In tip mode, meta-qcom was cloned into $PWD/meta-qcom but CI_YAML_DIR was set to $KAS_WORK_DIR/meta-qcom/ci. Since $KAS_WORK_DIR is $PWD/kas, the ci/ directory was never found, causing the subsequent cp and kas build commands to fail with 'No such file or directory'.

Pass $KAS_WORK_DIR/meta-qcom as the explicit clone destination so the clone lands where CI_YAML_DIR expects it. Update the git -C path accordingly.