### PR TITLE
ci: build_yocto: add support for unmerged meta-qcom PRs in the build

### DIFF
--- a/.github/actions/build_yocto/action.yml
+++ b/.github/actions/build_yocto/action.yml
@@ -32,6 +32,11 @@ inputs:
     description: Kernel Yaml to build
     type: string
     required: true
+  pr_list:
+    description: meta_qcom_pr list
+    type: string
+    required: false
+    default: ""
 
 outputs:
   artifacts_location:
@@ -69,6 +74,10 @@ runs:
         echo "LOGFILE=${{ github.workspace }}/build-logs.log" >> "$GITHUB_ENV"
 
         mkdir -p "$build_dir"
+        KAS_WORK_DIR="$build_dir/kas"
+        CI_YAML_DIR=$KAS_WORK_DIR/meta-qcom/ci
+        echo "KAS_WORK_DIR=$KAS_WORK_DIR" >> $GITHUB_ENV
+        echo "CI_YAML_DIR=$CI_YAML_DIR" >> $GITHUB_ENV
 
     - name: Configure AWS
       shell: bash
@@ -77,29 +86,29 @@ runs:
         aws configure set aws_secret_access_key "${{ env.AWS_SECRET_ACCESS_KEY}}" && \
         aws configure set default.region "${{ env.AWS_REGION}}"
 
-    - name: Set Kernel Version
+    - name: Set meta-qcom Branch name and kernel version
       shell: bash
       run: |
         set -ex
-        cd ${{ env.build_dir }}
-
         branch="${{ inputs.branch }}"
         if [ "$branch" == "qcom-6.18.y" ]; then
           kernel_ver="6.18"
+          meta_qcom_ref="wrynose"
         else
           kernel_ver="mainline"
+          meta_qcom_ref="master"
         fi
         echo "kernel_ver=$kernel_ver" >> $GITHUB_ENV
+        echo "meta_qcom_ref=$meta_qcom_ref" >> $GITHUB_ENV
 
     - name: Set Kernel override
       shell: bash
       run : |
         cd ${{ env.build_dir }}
-        aws s3 cp s3://${{ env.s3_bucket }}/meta-qcom/kas_files/$kernel_ver/kernel-override.yml .
-        kernel_ver="${{ env.kernel_ver }}"
+        aws s3 cp s3://${{ env.s3_bucket }}/meta-qcom/kas_files/${{ env.kernel_ver }}/kernel-override.yml .
         kernel_sha="${{ env.sha }}"
         echo "Kernel SHA : $kernel_sha"
-        if [[ "$kernel_ver" == "6.18" ]]; then
+        if [[ "${{ env.kernel_ver }}" == "6.18" ]]; then
           sed -i "s/SRCREV:pn-linux-qcom = \"[^\"]*\"/SRCREV:pn-linux-qcom = \"$kernel_sha\"/" kernel-override.yml
         else
           sed -i "s/SRCREV:pn-linux-qcom-next = \"[^\"]*\"/SRCREV:pn-linux-qcom-next = \"$kernel_sha\"/" kernel-override.yml
@@ -125,30 +134,23 @@ runs:
       run: |
         buildconf_repo="https://x-access-token:${{ env.token }}@github.com/qualcomm-linux/meta-qcom-buildconf.git"
         echo "buildconf_repo=$buildconf_repo" >> $GITHUB_ENV
-        base="${{ inputs.base }}"
-        branch="${{ inputs.branch }}"
         # Select ref prefix based on kernel branch
-        if [[ "$branch" == "qcom-6.18.y" ]]; then
-          ref_prefix="wrynose"
-        else
-          ref_prefix="master"
-        fi
-        if [[ "$base" == "tag" ]]; then
+        if [[ "${{ env.base }}" == "tag" ]]; then
           # Use the latest tag matching the prefix (wrynose-* or master-*)
           buildconf_ref="$(git ls-remote --tags "$buildconf_repo" \
                              | awk -F/ '{print $NF}' \
                              | sed 's/\^{}//' \
-                             | grep "^${ref_prefix}-" \
+                             | grep "^${{env.meta_qcom_ref}}-" \
                              | sort -V \
                              | tail -n 1
                            )"
         else
           # base is an explicit tag — use it as-is
-          buildconf_ref="$base"
+          buildconf_ref=${{ env.base }}
         fi
         echo "buildconf_ref=$buildconf_ref" >> $GITHUB_ENV
 
-    - name: Run Kas Build
+    - name: Setup Build Workspace
       id: build
       shell: bash
       run: |
@@ -156,46 +158,68 @@ runs:
         cd ${{ env.build_dir }}
         mkdir kas
         ls -la
-        export KAS_WORK_DIR=$PWD/kas
+        export KAS_WORK_DIR=${{ env.KAS_WORK_DIR }}
         echo $KAS_WORK_DIR
-        kernel_ver="${{ env.kernel_ver }}"
-        base="${{ inputs.base }}"
-        branch="${{ inputs.branch }}"
-
-        if [[ "$base" == "tip" ]]; then
-          echo "Building from meta-qcom tip"
-
-          if [[ "$branch" == "qcom-6.18.y" ]]; then
-            meta_qcom_ref="wrynose"
-          else
-            meta_qcom_ref="master"
-          fi
-
-          git clone https://github.com/qualcomm-linux/meta-qcom.git -b $meta_qcom_ref "$KAS_WORK_DIR/meta-qcom"
-          meta_qcom_sha=$(git -C "$KAS_WORK_DIR/meta-qcom" rev-parse HEAD)
+        lock_arg=""
+        if [[ "${{ env.base }}" == "tip" ]]; then
+          echo "Building from tip"
+          git clone https://github.com/qualcomm-linux/meta-qcom.git -b ${{env.meta_qcom_ref}} "${{ env.KAS_WORK_DIR}}/meta-qcom"
+          meta_qcom_sha=$(git -C "${{ env.KAS_WORK_DIR}}/meta-qcom" rev-parse HEAD)
           echo $meta_qcom_sha > build_id.txt
           cat build_id.txt
-          cat kernel-override.yml
-          CI_YAML_DIR=$KAS_WORK_DIR/meta-qcom/ci
-          cp kernel-override.yml $CI_YAML_DIR
-          $KAS_CONTAINER build $CI_YAML_DIR/${{ env.rootfs }}.yml:$CI_YAML_DIR/${{ inputs.kernel_yaml }}.yml:$CI_YAML_DIR/qcom-distro.yml:$CI_YAML_DIR/kernel-override.yml
+
         else
           echo "meta-qcom-buildconf ref : ${{ env.buildconf_ref }}"
           git clone ${{ env.buildconf_repo }} -b  ${{ env.buildconf_ref }}
           $KAS_CONTAINER checkout meta-qcom-buildconf/lock.yml
           cp meta-qcom-buildconf/lock.yml $KAS_WORK_DIR/meta-qcom/ci/lock.yml
-          cat kernel-override.yml
-          CI_YAML_DIR=$KAS_WORK_DIR/meta-qcom/ci
-          cp kernel-override.yml $CI_YAML_DIR
-          $KAS_CONTAINER build $CI_YAML_DIR/${{ env.rootfs }}.yml:$CI_YAML_DIR/${{ inputs.kernel_yaml }}.yml:$CI_YAML_DIR/qcom-distro.yml:$CI_YAML_DIR/kernel-override.yml:$CI_YAML_DIR/lock.yml
+          lock_arg=":${{ env.CI_YAML_DIR }}/lock.yml"
         fi
+        echo "lock arg : $lock_arg"
+        echo "lock_arg=$lock_arg" >> $GITHUB_ENV
+        cat kernel-override.yml
+        cp kernel-override.yml ${{ env.CI_YAML_DIR }}
 
-        if [[ "$kernel_ver" == "6.18" ]]; then
+    - name: Apply Unmerged meta-qcom PR's
+      if: ${{ inputs.pr_list != '' }}
+      shell: bash
+      run: |
+        cd "${{ env.KAS_WORK_DIR}}/meta-qcom"
+        echo "Merging meta-qcom PR(s): ${{ inputs.pr_list }}"
+        for pr in ${{ inputs.pr_list }}; do
+          echo "::group::Merging meta-qcom PR #$pr"
+          git fetch --no-tags origin "pull/$pr/head:pr-$pr"
+
+          if ! git merge "pr-$pr" --no-commit; then
+            echo "ERROR: Merge conflict while merging PR #$pr. Aborting."
+            git merge --abort || true
+            exit 1
+          fi
+
+          if ! git diff --cached --quiet; then
+            git commit -m "Merged qcom-next PR #$pr"
+            echo "PR #$pr merged successfully."
+          else
+            echo "Nothing to commit for PR #$pr (already merged or fast-forwarded)."
+            git merge --abort 2>/dev/null || true
+          fi
+          echo "::endgroup::"
+        done
+
+    - name: Build
+      shell: bash
+      run: |
+        cd ${{ env.build_dir }}
+        echo "In build : lock_arg : ${{ env.lock_arg }}"
+        $KAS_CONTAINER build ${{ env.CI_YAML_DIR }}/${{ env.rootfs }}.yml:${{ env.CI_YAML_DIR }}/${{ inputs.kernel_yaml }}.yml:${{ env.CI_YAML_DIR }}/qcom-distro.yml:${{ env.CI_YAML_DIR }}/kernel-override.yml${{ env.lock_arg }}
+
+        if [[ "${{ env.kernel_ver }}" == "6.18" ]]; then
           recipe="linux-qcom"
         else
           recipe="linux-qcom-next"
         fi
-        raw_ver=$($KAS_CONTAINER shell $CI_YAML_DIR/${{ env.rootfs }}.yml:$CI_YAML_DIR/${{ inputs.kernel_yaml }}.yml:$CI_YAML_DIR/qcom-distro.yml:$CI_YAML_DIR/kernel-override.yml -c "bitbake -e $recipe | grep '^KERNEL_VERSION='" | cut -d'"' -f2)
+
+        raw_ver=$($KAS_CONTAINER shell ${{ env.CI_YAML_DIR }}/${{ env.rootfs }}.yml:${{ env.CI_YAML_DIR }}/${{ inputs.kernel_yaml }}.yml:${{ env.CI_YAML_DIR }}/qcom-distro.yml:${{ env.CI_YAML_DIR }}/kernel-override.yml${{ env.lock_arg }} -c "bitbake -e $recipe | grep '^KERNEL_VERSION='" | cut -d'"' -f2)
         echo "raw_kernel_version=$raw_ver" >> $GITHUB_ENV
 
     - name: Get Kernel Version

--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -25,6 +25,11 @@ on:
         description: base build or tip
         type: string
         required: true
+      pr_list:
+        description: list of open PR's
+        type: string
+        default: ''
+        required: false
     outputs:
       artifacts_location:
         description: 'Artifacts Upload location'
@@ -99,6 +104,7 @@ jobs:
           branch: ${{ inputs.ref }}
           base: ${{ inputs.base }}
           kernel_yaml: ${{ needs.kas-setup.outputs.kernel_yaml }}
+          pr_list: ${{ inputs.pr_list }}
         env:
           token: ${{ secrets.PAT }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/post-merge-yocto.yml
+++ b/.github/workflows/post-merge-yocto.yml
@@ -22,6 +22,11 @@ on:
         type: string
         default: tip
         required: true
+      pr_list:
+        description: list of open PR's
+        type: string
+        default: ''
+        required: false
 
 jobs:
   init-status:
@@ -71,6 +76,7 @@ jobs:
       SHA: ${{ inputs.sha }}
       rootfs_matrix: ${{ needs.loading.outputs.rootfs_matrix }}
       base: ${{ inputs.base }}
+      pr_list: ${{ inputs.pr_list }}
 
   check_run:
     runs-on: ubuntu-latest

--- a/.github/workflows/post_merge_nightly.yml
+++ b/.github/workflows/post_merge_nightly.yml
@@ -12,6 +12,11 @@ on:
         type: string
         default: tag
         required: true
+      meta_qcom_pr:
+        description: List of meta-qcom PR's
+        type: string
+        default: ''
+        required: false
 
 jobs:
   fetch_head_sha:
@@ -38,3 +43,4 @@ jobs:
       ref: "qcom-6.18.y"
       repo: "qualcomm-linux/kernel"
       base: ${{ inputs.base || 'tag' }}
+      pr_list: ${{ inputs.meta_qcom_pr }}

--- a/.github/workflows/pre-merge-yocto.yml
+++ b/.github/workflows/pre-merge-yocto.yml
@@ -26,6 +26,11 @@ on:
         type: string
         default: tag
         required: true
+      pr_list:
+        description: list of open PR's
+        type: string
+        default: ''
+        required: false
 
 jobs:
   init-status:
@@ -71,6 +76,7 @@ jobs:
       sha: ${{ inputs.sha }}
       rootfs_matrix: ${{ needs.loading.outputs.rootfs_matrix }}
       base: ${{ inputs.base }}
+      pr_list: ${{ inputs.pr_list }}
 
   check_run:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Introduce a pr_list input across the workflow chain to allow one or more unmerged meta-qcom pull requests to be merged into the cloned meta-qcom tree before the Yocto build runs.