### PR TITLE
ci: build_yocto: pin meta-qcom to local path when merging unmerged PRs

### DIFF
--- a/.github/actions/build_yocto/action.yml
+++ b/.github/actions/build_yocto/action.yml
@@ -201,17 +201,26 @@ runs:
             echo "PR #$pr merged successfully."
           else
             echo "Nothing to commit for PR #$pr (already merged or fast-forwarded)."
-            git merge --abort 2>/dev/null || true
           fi
           echo "::endgroup::"
         done
+
+        cat > "${{ env.CI_YAML_DIR }}/meta_qcom_override.yml" <<EOF
+        header:
+          version: 14
+        repos:
+          meta-qcom:
+            path:
+            url:
+        EOF
+        echo "pr_override_arg=:${{ env.CI_YAML_DIR }}/meta_qcom_override.yml" >> $GITHUB_ENV
 
     - name: Build
       shell: bash
       run: |
         cd ${{ env.build_dir }}
         echo "In build : lock_arg : ${{ env.lock_arg }}"
-        $KAS_CONTAINER build ${{ env.CI_YAML_DIR }}/${{ env.rootfs }}.yml:${{ env.CI_YAML_DIR }}/${{ inputs.kernel_yaml }}.yml:${{ env.CI_YAML_DIR }}/qcom-distro.yml:${{ env.CI_YAML_DIR }}/kernel-override.yml${{ env.lock_arg }}
+        $KAS_CONTAINER build ${{ env.CI_YAML_DIR }}/${{ env.rootfs }}.yml:${{ env.CI_YAML_DIR }}/${{ inputs.kernel_yaml }}.yml:${{ env.CI_YAML_DIR }}/qcom-distro.yml:${{ env.CI_YAML_DIR }}/kernel-override.yml${{ env.lock_arg }}${{ env.pr_override_arg }}
 
         if [[ "${{ env.kernel_ver }}" == "6.18" ]]; then
           recipe="linux-qcom"
@@ -219,7 +228,7 @@ runs:
           recipe="linux-qcom-next"
         fi
 
-        raw_ver=$($KAS_CONTAINER shell ${{ env.CI_YAML_DIR }}/${{ env.rootfs }}.yml:${{ env.CI_YAML_DIR }}/${{ inputs.kernel_yaml }}.yml:${{ env.CI_YAML_DIR }}/qcom-distro.yml:${{ env.CI_YAML_DIR }}/kernel-override.yml${{ env.lock_arg }} -c "bitbake -e $recipe | grep '^KERNEL_VERSION='" | cut -d'"' -f2)
+        raw_ver=$($KAS_CONTAINER shell ${{ env.CI_YAML_DIR }}/${{ env.rootfs }}.yml:${{ env.CI_YAML_DIR }}/${{ inputs.kernel_yaml }}.yml:${{ env.CI_YAML_DIR }}/qcom-distro.yml:${{ env.CI_YAML_DIR }}/kernel-override.yml${{ env.lock_arg }}${{ env.pr_override_arg }} -c "bitbake -e $recipe | grep '^KERNEL_VERSION='" | cut -d'"' -f2)
         echo "raw_kernel_version=$raw_ver" >> $GITHUB_ENV
 
     - name: Get Kernel Version


### PR DESCRIPTION
When unmerged meta-qcom PRs are merged locally before the build, the kas lock.yml still references meta-qcom by its remote url and pinned commit. At build time kas re-clones from the remote url and resets meta-qcom to the locked commit, discarding the locally merged state.

Fix this by generating a kas overlay file meta_qcom_override.yml after all PRs are merged. The overlay declares meta-qcom with path set to /work/meta-qcom (the container-internal path where meta-qcom is already cloned) and url left empty. When kas sees url as null it sets disable_operations on that repo, using the directory as-is without any fetch or checkout. The overlay is appended last in the kas config chain via pr_override_arg so it takes precedence over lock.yml while leaving all other layer pins untouched.

The overlay is only generated and appended when pr_list is non-empty, so builds without unmerged PRs are unaffected.

Also drop the erroneous git merge --abort call that was reached after a fast-forward merge where there is no merge in progress to abort.