### PR TITLE
qcom-next.conf: add optee topic branch

### DIFF
--- a/qcom-next.conf
+++ b/qcom-next.conf
@@ -50,6 +50,7 @@ tech/pm/thermal            https://github.com/qualcomm-linux/kernel-topics.git  
 tech/security/crypto       https://github.com/qualcomm-linux/kernel-topics.git       tech/security/crypto
 tech/security/fscrypt      https://github.com/qualcomm-linux/kernel-topics.git       tech/security/fscrypt
 tech/security/ice          https://github.com/qualcomm-linux/kernel-topics.git       tech/security/ice
+tech/security/optee        https://github.com/qualcomm-linux/kernel-topics.git       tech/security/optee
 tech/storage/nvmem         https://github.com/qualcomm-linux/kernel-topics.git       tech/storage/nvmem
 tech/storage/phy           https://github.com/qualcomm-linux/kernel-topics.git       tech/storage/phy
 tech/storage/all           https://github.com/qualcomm-linux/kernel-topics.git       tech/storage/all


### PR DESCRIPTION
Add OP-TEE topic branch to qcom-next.conf carrying in flight patches to enable OP-TEE based TZ services.

This is a re-revert of PR: https://github.com/qualcomm-linux/kernel-config/pull/211. The OP-TEE topic branch is now rebased to qcom-next tip to cover all the merge conflicts. Please merge OP-TEE topic branch as the last one.

@sgaud-quic @shashim-quic 