### PR TITLE
ci: Dont use kernel_yaml for Build

### DIFF
--- a/.github/actions/build_yocto/action.yml
+++ b/.github/actions/build_yocto/action.yml
@@ -220,7 +220,7 @@ runs:
       run: |
         cd ${{ env.build_dir }}
         echo "In build : lock_arg : ${{ env.lock_arg }}"
-        $KAS_CONTAINER build ${{ env.CI_YAML_DIR }}/${{ env.rootfs }}.yml:${{ env.CI_YAML_DIR }}/${{ inputs.kernel_yaml }}.yml:${{ env.CI_YAML_DIR }}/qcom-distro.yml:${{ env.CI_YAML_DIR }}/kernel-override.yml${{ env.lock_arg }}${{ env.pr_override_arg }}
+        $KAS_CONTAINER build ${{ env.CI_YAML_DIR }}/${{ env.rootfs }}.yml:${{ env.CI_YAML_DIR }}/qcom-distro.yml:${{ env.CI_YAML_DIR }}/kernel-override.yml${{ env.lock_arg }}${{ env.pr_override_arg }}
 
         if [[ "${{ env.kernel_ver }}" == "6.18" ]]; then
           recipe="linux-qcom"
@@ -228,7 +228,7 @@ runs:
           recipe="linux-qcom-next"
         fi
 
-        raw_ver=$($KAS_CONTAINER shell ${{ env.CI_YAML_DIR }}/${{ env.rootfs }}.yml:${{ env.CI_YAML_DIR }}/${{ inputs.kernel_yaml }}.yml:${{ env.CI_YAML_DIR }}/qcom-distro.yml:${{ env.CI_YAML_DIR }}/kernel-override.yml${{ env.lock_arg }}${{ env.pr_override_arg }} -c "bitbake -e $recipe | grep '^KERNEL_VERSION='" | cut -d'"' -f2)
+        raw_ver=$($KAS_CONTAINER shell ${{ env.CI_YAML_DIR }}/${{ env.rootfs }}.yml:${{ env.CI_YAML_DIR }}/qcom-distro.yml:${{ env.CI_YAML_DIR }}/kernel-override.yml${{ env.lock_arg }}${{ env.pr_override_arg }} -c "bitbake -e $recipe | grep '^KERNEL_VERSION='" | cut -d'"' -f2)
         echo "raw_kernel_version=$raw_ver" >> $GITHUB_ENV
 
     - name: Get Kernel Version


### PR DESCRIPTION
Dont use kernel_yaml for build, so default kernel
for the branch will be used