### PR TITLE
ci: Enable PMIC branches for pre-merge rootfs generation

### DIFF
--- a/ci/MACHINES.json
+++ b/ci/MACHINES.json
@@ -8,7 +8,7 @@
     "firmwareid": "rb3gen2",
     "rootfs": "rb3gen2-core-kit",
     "flash_type": "qdl",
-    "branches": ["qcom-next-staging", "qcom-6.18.y", "tech/mproc/rpmsg", "tech/mproc/all", "tech/net/qrtr", "tech/storage/all", "tech/storage/phy"]
+    "branches": ["qcom-next-staging", "qcom-6.18.y", "tech/mproc/rpmsg", "tech/mproc/all", "tech/net/qrtr", "tech/storage/all", "tech/storage/phy", "tech/pmic/backlight", "tech/pmic/mfd", "tech/pmic/misc", "tech/pmic/regulator", "tech/pmic/supply"]
   },
   "qcs9100-ride-r3": {
     "machine": "qcs9100-ride-r3",
@@ -19,7 +19,7 @@
     "firmwareid": "sa8775p-ride",
     "rootfs": "qcs9100-ride-sx",
     "flash_type": "qdl",
-    "branches": ["qcom-next-staging", "qcom-6.18.y", "tech/mproc/rpmsg", "tech/mproc/all", "tech/net/qrtr", "tech/storage/all", "tech/storage/phy"]
+    "branches": ["qcom-next-staging", "qcom-6.18.y", "tech/mproc/rpmsg", "tech/mproc/all", "tech/net/qrtr", "tech/storage/all", "tech/storage/phy", "tech/pmic/backlight", "tech/pmic/mfd", "tech/pmic/misc", "tech/pmic/regulator", "tech/pmic/supply"]
   },
   "qcs8300-ride": {
     "machine": "qcs8300-ride",
@@ -30,7 +30,7 @@
     "firmwareid": "qcs8300-ride",
     "rootfs": "qcs8300-ride-sx",
     "flash_type": "qdl",
-    "branches": ["qcom-next-staging", "qcom-6.18.y", "tech/mproc/rpmsg", "tech/mproc/all", "tech/net/qrtr", "tech/storage/all", "tech/storage/phy"]
+    "branches": ["qcom-next-staging", "qcom-6.18.y", "tech/mproc/rpmsg", "tech/mproc/all", "tech/net/qrtr", "tech/storage/all", "tech/storage/phy", "tech/pmic/backlight", "tech/pmic/mfd", "tech/pmic/misc", "tech/pmic/regulator", "tech/pmic/supply"]
   },
   "sm8750-mtp": {
     "machine": "sm8750-mtp",
@@ -41,7 +41,7 @@
     "firmwareid": "sm8750-mtp",
     "rootfs": "sm8750-mtp",
     "flash_type": "qdl",
-    "branches": ["qcom-next-staging", "tech/mproc/rpmsg", "tech/mproc/all", "tech/net/qrtr", "tech/storage/all", "tech/storage/phy"]
+    "branches": ["qcom-next-staging", "tech/mproc/rpmsg", "tech/mproc/all", "tech/net/qrtr", "tech/storage/all", "tech/storage/phy", "tech/pmic/backlight", "tech/pmic/mfd", "tech/pmic/misc", "tech/pmic/regulator", "tech/pmic/supply"]
   },
   "lemans-evk": {
     "machine": "lemans-evk",
@@ -52,7 +52,7 @@
     "firmwareid": "sa8775p-ride",
     "rootfs": "iq-9075-evk",
     "flash_type": "qdl",
-    "branches": ["qcom-next-staging", "qcom-6.18.y", "tech/mproc/rpmsg", "tech/mproc/all", "tech/net/qrtr", "tech/storage/all", "tech/storage/phy"]
+    "branches": ["qcom-next-staging", "qcom-6.18.y", "tech/mproc/rpmsg", "tech/mproc/all", "tech/net/qrtr", "tech/storage/all", "tech/storage/phy", "tech/pmic/backlight", "tech/pmic/mfd", "tech/pmic/misc", "tech/pmic/regulator", "tech/pmic/supply"]
   },
   "monaco-evk": {
     "machine": "monaco-evk",
@@ -63,7 +63,7 @@
     "firmwareid": "qcs8300-ride",
     "rootfs": "iq-8275-evk",
     "flash_type": "qdl",
-    "branches": ["qcom-next-staging", "qcom-6.18.y", "tech/mproc/rpmsg", "tech/mproc/all", "tech/net/qrtr", "tech/storage/all", "tech/storage/phy"]
+    "branches": ["qcom-next-staging", "qcom-6.18.y", "tech/mproc/rpmsg", "tech/mproc/all", "tech/net/qrtr", "tech/storage/all", "tech/storage/phy", "tech/pmic/backlight", "tech/pmic/mfd", "tech/pmic/misc", "tech/pmic/regulator", "tech/pmic/supply"]
   },
   "qcs615-adp-air": {
     "machine": "qcs615-ride",
@@ -74,7 +74,7 @@
     "firmwareid": "qcs615-ride",
     "rootfs": "qcs615-ride",
     "flash_type": "qdl",
-    "branches": ["qcom-next-staging", "qcom-6.18.y", "tech/mproc/rpmsg", "tech/mproc/all", "tech/net/qrtr", "tech/storage/all", "tech/storage/phy"]
+    "branches": ["qcom-next-staging", "qcom-6.18.y", "tech/mproc/rpmsg", "tech/mproc/all", "tech/net/qrtr", "tech/storage/all", "tech/storage/phy", "tech/pmic/backlight", "tech/pmic/mfd", "tech/pmic/misc", "tech/pmic/regulator", "tech/pmic/supply"]
   },
   "kaanapali-mtp": {
     "machine": "kaanapali-mtp",
@@ -85,7 +85,7 @@
     "firmwareid": "kaanapali-mtp",
     "rootfs": "kaanapali-mtp",
     "flash_type": "qdl",
-    "branches": ["qcom-next-staging"]
+    "branches": ["qcom-next-staging", "tech/pmic/backlight", "tech/pmic/mfd", "tech/pmic/misc", "tech/pmic/regulator", "tech/pmic/supply"]
   },
   "hamoa-iot-evk": {
     "machine": "hamoa-iot-evk",
@@ -96,7 +96,7 @@
     "firmwareid": "iq-x7181-evk",
     "rootfs": "iq-x7181-evk",
     "flash_type": "qdl",
-    "branches": ["qcom-next-staging", "qcom-6.18.y", "tech/mproc/rpmsg", "tech/mproc/all", "tech/net/qrtr", "tech/storage/all", "tech/storage/phy"]
+    "branches": ["qcom-next-staging", "qcom-6.18.y", "tech/mproc/rpmsg", "tech/mproc/all", "tech/net/qrtr", "tech/storage/all", "tech/storage/phy", "tech/pmic/backlight", "tech/pmic/mfd", "tech/pmic/misc", "tech/pmic/regulator", "tech/pmic/supply"]
   },
   "glymur-crd": {
     "machine": "glymur-crd",
@@ -107,7 +107,7 @@
     "firmwareid": "glymur-crd",
     "rootfs": "glymur-crd",
     "flash_type": "qdl",
-    "branches": ["qcom-next-staging"]
+    "branches": ["qcom-next-staging", "tech/pmic/backlight", "tech/pmic/mfd", "tech/pmic/misc", "tech/pmic/regulator", "tech/pmic/supply"]
   },
   "qrb2210-rb1": {
     "machine": "qrb2210-rb1",
@@ -118,6 +118,6 @@
     "firmwareid": "rb1",
     "rootfs": "rb1-core-kit",
     "flash_type": "qdl",
-    "branches": ["qcom-next-staging"]
+    "branches": ["qcom-next-staging", "tech/pmic/backlight", "tech/pmic/mfd", "tech/pmic/misc", "tech/pmic/regulator", "tech/pmic/supply"]
   }
 }


### PR DESCRIPTION
Add tech/pmic/backlight, tech/pmic/mfd, tech/pmic/misc, tech/pmic/regulator and tech/pmic/supply to the per-target branches list to ensure that pre-merge flat-meta rootfs assembly runs for PRs targeting these topic branches.