### PR TITLE
ci: Enable pmic topic branches for pre-merge rootfs generation

### DIFF
--- a/ci/MACHINES.json
+++ b/ci/MACHINES.json
@@ -9,7 +9,7 @@
     "rootfs": "rb3gen2-core-kit",
     "flash_type": "qdl",
     "hypervisor": "gunyah",
-    "branches": ["qcom-next-staging", "qcom-6.18.y", "tech/mproc/rpmsg", "tech/mproc/all", "tech/net/qrtr", "tech/storage/all", "tech/storage/phy"]
+    "branches": ["qcom-next-staging", "qcom-6.18.y", "tech/mproc/rpmsg", "tech/mproc/all", "tech/net/qrtr", "tech/storage/all", "tech/storage/phy", "tech/pmic/supply", "tech/pmic/regulator", "tech/pmic/misc", "tech/pmic/mfd", "tech/pmic/backlight", "tech/bus/usb/phy", "tech/bus/usb/dwc", "tech/bus/usb/gadget", "tech/bsp/clk", "tech/bsp/interconnect"]
   },
   "qcs9100-ride-r3": {
     "machine": "qcs9100-ride-r3",
@@ -21,7 +21,7 @@
     "rootfs": "qcs9100-ride-sx",
     "flash_type": "qdl",
     "hypervisor": "kvm",
-    "branches": ["qcom-next-staging", "qcom-6.18.y", "tech/mproc/rpmsg", "tech/mproc/all", "tech/net/qrtr", "tech/storage/all", "tech/storage/phy"]
+    "branches": ["qcom-next-staging", "qcom-6.18.y", "tech/mproc/rpmsg", "tech/mproc/all", "tech/net/qrtr", "tech/storage/all", "tech/storage/phy", "tech/pmic/supply", "tech/pmic/regulator", "tech/pmic/misc", "tech/pmic/mfd", "tech/pmic/backlight", "tech/bus/usb/phy", "tech/bus/usb/dwc", "tech/bus/usb/gadget", "tech/bsp/clk", "tech/bsp/interconnect"]
   },
   "qcs8300-ride": {
     "machine": "qcs8300-ride",
@@ -32,8 +32,8 @@
     "firmwareid": "qcs8300-ride",
     "rootfs": "qcs8300-ride-sx",
     "flash_type": "qdl",
-    "hypervisor": "gunyah",
-    "branches": ["qcom-next-staging", "qcom-6.18.y", "tech/mproc/rpmsg", "tech/mproc/all", "tech/net/qrtr", "tech/storage/all", "tech/storage/phy"]
+    "hypervisor": "kvm",
+    "branches": ["qcom-next-staging", "qcom-6.18.y", "tech/mproc/rpmsg", "tech/mproc/all", "tech/net/qrtr", "tech/storage/all", "tech/storage/phy", "tech/pmic/supply", "tech/pmic/regulator", "tech/pmic/misc", "tech/pmic/mfd", "tech/pmic/backlight", "tech/bus/usb/phy", "tech/bus/usb/dwc", "tech/bus/usb/gadget", "tech/bsp/clk", "tech/bsp/interconnect"]
   },
   "sm8750-mtp": {
     "machine": "sm8750-mtp",
@@ -45,7 +45,7 @@
     "rootfs": "sm8750-mtp",
     "flash_type": "qdl",
     "hypervisor": "gunyah",
-    "branches": ["qcom-next-staging", "tech/mproc/rpmsg", "tech/mproc/all", "tech/net/qrtr", "tech/storage/all", "tech/storage/phy"]
+    "branches": ["qcom-next-staging", "tech/mproc/rpmsg", "tech/mproc/all", "tech/net/qrtr", "tech/storage/all", "tech/storage/phy", "tech/pmic/supply", "tech/pmic/regulator", "tech/pmic/misc", "tech/pmic/mfd", "tech/pmic/backlight", "tech/bus/usb/phy", "tech/bus/usb/dwc", "tech/bus/usb/gadget", "tech/bsp/clk", "tech/bsp/interconnect"]
   },
   "lemans-evk": {
     "machine": "lemans-evk",
@@ -57,7 +57,7 @@
     "rootfs": "iq-9075-evk",
     "flash_type": "qdl",
     "hypervisor": "kvm",
-    "branches": ["qcom-next-staging", "qcom-6.18.y", "tech/mproc/rpmsg", "tech/mproc/all", "tech/net/qrtr", "tech/storage/all", "tech/storage/phy"]
+    "branches": ["qcom-next-staging", "qcom-6.18.y", "tech/mproc/rpmsg", "tech/mproc/all", "tech/net/qrtr", "tech/storage/all", "tech/storage/phy", "tech/pmic/supply", "tech/pmic/regulator", "tech/pmic/misc", "tech/pmic/mfd", "tech/pmic/backlight", "tech/bus/usb/phy", "tech/bus/usb/dwc", "tech/bus/usb/gadget", "tech/bsp/clk", "tech/bsp/interconnect"]
   },
   "monaco-evk": {
     "machine": "monaco-evk",
@@ -69,7 +69,7 @@
     "rootfs": "iq-8275-evk",
     "flash_type": "qdl",
     "hypervisor": "kvm",
-    "branches": ["qcom-next-staging", "qcom-6.18.y", "tech/mproc/rpmsg", "tech/mproc/all", "tech/net/qrtr", "tech/storage/all", "tech/storage/phy"]
+    "branches": ["qcom-next-staging", "qcom-6.18.y", "tech/mproc/rpmsg", "tech/mproc/all", "tech/net/qrtr", "tech/storage/all", "tech/storage/phy", "tech/pmic/supply", "tech/pmic/regulator", "tech/pmic/misc", "tech/pmic/mfd", "tech/pmic/backlight", "tech/bus/usb/phy", "tech/bus/usb/dwc", "tech/bus/usb/gadget", "tech/bsp/clk", "tech/bsp/interconnect"]
   },
   "qcs615-adp-air": {
     "machine": "qcs615-ride",
@@ -81,7 +81,7 @@
     "rootfs": "qcs615-ride",
     "flash_type": "qdl",
     "hypervisor": "gunyah",
-    "branches": ["qcom-next-staging", "qcom-6.18.y", "tech/mproc/rpmsg", "tech/mproc/all", "tech/net/qrtr", "tech/storage/all", "tech/storage/phy"]
+    "branches": ["qcom-next-staging", "qcom-6.18.y", "tech/mproc/rpmsg", "tech/mproc/all", "tech/net/qrtr", "tech/storage/all", "tech/storage/phy", "tech/pmic/supply", "tech/pmic/regulator", "tech/pmic/misc", "tech/pmic/mfd", "tech/pmic/backlight", "tech/bus/usb/phy", "tech/bus/usb/dwc", "tech/bus/usb/gadget", "tech/bsp/clk", "tech/bsp/interconnect"]
   },
   "kaanapali-mtp": {
     "machine": "kaanapali-mtp",
@@ -93,7 +93,7 @@
     "rootfs": "kaanapali-mtp",
     "flash_type": "qdl",
     "hypervisor": "gunyah",
-    "branches": ["qcom-next-staging"]
+    "branches": ["qcom-next-staging", "tech/pmic/supply", "tech/pmic/regulator", "tech/pmic/misc", "tech/pmic/mfd", "tech/pmic/backlight", "tech/bus/usb/phy", "tech/bus/usb/dwc", "tech/bus/usb/gadget", "tech/bsp/clk", "tech/bsp/interconnect"]
   },
   "hamoa-iot-evk": {
     "machine": "hamoa-iot-evk",
@@ -105,7 +105,7 @@
     "rootfs": "iq-x7181-evk",
     "flash_type": "qdl",
     "hypervisor": "gunyah",
-    "branches": ["qcom-next-staging", "qcom-6.18.y", "tech/mproc/rpmsg", "tech/mproc/all", "tech/net/qrtr", "tech/storage/all", "tech/storage/phy"]
+    "branches": ["qcom-next-staging", "qcom-6.18.y", "tech/mproc/rpmsg", "tech/mproc/all", "tech/net/qrtr", "tech/storage/all", "tech/storage/phy", "tech/pmic/supply", "tech/pmic/regulator", "tech/pmic/misc", "tech/pmic/mfd", "tech/pmic/backlight", "tech/bus/usb/phy", "tech/bus/usb/dwc", "tech/bus/usb/gadget", "tech/bsp/clk", "tech/bsp/interconnect"]
   },
   "glymur-crd": {
     "machine": "glymur-crd",
@@ -117,7 +117,7 @@
     "rootfs": "glymur-crd",
     "flash_type": "qdl",
     "hypervisor": "gunyah",
-    "branches": ["qcom-next-staging"]
+    "branches": ["qcom-next-staging", "tech/pmic/supply", "tech/pmic/regulator", "tech/pmic/misc", "tech/pmic/mfd", "tech/pmic/backlight", "tech/bus/usb/phy", "tech/bus/usb/dwc", "tech/bus/usb/gadget", "tech/bsp/clk", "tech/bsp/interconnect"]
   },
   "qrb2210-rb1": {
     "machine": "qrb2210-rb1",
@@ -129,6 +129,6 @@
     "rootfs": "rb1-core-kit",
     "flash_type": "qdl",
     "hypervisor": "gunyah",
-    "branches": ["qcom-next-staging"]
+    "branches": ["qcom-next-staging", "tech/pmic/supply", "tech/pmic/regulator", "tech/pmic/misc", "tech/pmic/mfd", "tech/pmic/backlight", "tech/bus/usb/phy", "tech/bus/usb/dwc", "tech/bus/usb/gadget", "tech/bsp/clk", "tech/bsp/interconnect"]
   }
 }


### PR DESCRIPTION
Add tech/pmic/supply, tech/pmic/regulator, tech/pmic/misc, tech/pmic/mfd, and tech/pmic/backlight to the per-target branches list so that pre-merge flat-meta rootfs assembly runs for PRs targeting these topic branches.

These branches were excluded after the branch filter was introduced in PR #200 (ci: Filter test targets by branch using per-target branches list).

Signed-off-by: Raj Aryan <raryan@qti.qualcomm.com>