### PR TITLE
ci: Update cmdline parameter for QCS8300

### DIFF
--- a/.github/actions/flat_meta_generation/action.yml
+++ b/.github/actions/flat_meta_generation/action.yml
@@ -86,19 +86,25 @@ runs:
             devicetree_arg=""
           fi
 
+          cmdline="console=ttyMSM0,115200n8 earlycon qcom_geni_serial.con_enabled=1 qcom_scm.download_mode=1 reboot=panic_warm panic=-1 mitigations=auto copy-modules rootdelay=10 root=PARTLABEL=rootfs"
+          if [ "$machine" = "monaco-evk" ] || [ "$machine" = "qcs8300-ride" ]; then
+            cmdline="$cmdline arm64.nopauth"
+          fi
+
           docker run -i --rm \
             --user "$(id -u):$(id -g)" \
             --workdir="$PWD" \
             -v "$(dirname "$PWD")":"$(dirname "$PWD")" \
             -e machine="$machine" \
             -e devicetree_arg="$devicetree_arg" \
+            -e cmdline="$cmdline" \
             "$docker_image" bash -c '
               generate_boot_bins.sh efi \
                 --ramdisk artifacts/initramfs-$machine.cpio.gz \
                 --systemd-boot artifacts/systemd/usr/lib/systemd/boot/efi/systemd-bootaa64.efi \
                 --stub artifacts/systemd/usr/lib/systemd/boot/efi/linuxaa64.efi.stub \
                 --linux ../kobj/arch/arm64/boot/Image \
-                --cmdline "console=ttyMSM0,115200n8 earlycon qcom_geni_serial.con_enabled=1 qcom_scm.download_mode=1 reboot=panic_warm panic=-1 mitigations=auto copy-modules rootdelay=10 root=PARTLABEL=rootfs" \
+                --cmdline "$cmdline" \
                 $devicetree_arg \
                 --output images
             '


### PR DESCRIPTION
Update cmdline parameter for QCS8300 to disable PAuth

As KVM is enabled by default on QCS8300 and RB8, disable PAuth on QCS8300 to be inline with meta-qcom.

Change done on meta-qcom to disable this :
https://github.com/qualcomm-linux/meta-qcom/pull/1636

On QCS8300 platforms, ARM64 Pointer Authentication (PAuth) is supported
only on the boot CPUs (0–3) and not on the secondary CPUs (4–7). The
ARM64 CPU feature discovery logic expects secondary CPUs to support all
features enabled on the boot CPU. When this mismatch is detected, the
secondary CPUs are prevented from booting, which is undesirable for
production systems.

To ensure that all CPUs can boot correctly, disable PAuth by appending
`arm64.nopauth` to the kernel cmdline.

This issue is observed only when Linux is booted in EL2 (i.e. KVM in use).
When Linux runs under Gunyah (Type‑1 hypervisor), the PAuth feature is
hidden from EL1 via HCR_EL2.TID3.