### PR TITLE
ci: select DTBs by hypervisor for flat meta builds

### DIFF
--- a/.github/actions/flat_meta_generation/action.yml
+++ b/.github/actions/flat_meta_generation/action.yml
@@ -30,10 +30,12 @@ runs:
           machine=$(echo "$row" | jq -r '.machine')
           rootfs=$(echo "$row" | jq -r '.rootfs')
           firmwareid=$(echo "$row" | jq -r '.firmwareid')
+          hypervisor=$(echo "$row" | jq -r '.hypervisor // ""')
 
           echo "Target : $machine"
           echo "Rootfs ID : $rootfs"
           echo "Firmware ID : $firmwareid"
+          echo "Hypervisor : $hypervisor"
           echo "-----------------------------"
 
           if [ -z "$rootfs" ]; then
@@ -91,6 +93,11 @@ runs:
             cmdline="$cmdline arm64.nopauth"
           fi
 
+          dtb_path="../kobj/arch/arm64/boot/dts/qcom/$machine.dtb"
+          if [ "$hypervisor" = "kvm" ]; then
+            dtb_path="../kobj/arch/arm64/boot/dts/qcom/$machine-el2.dtb"
+          fi
+
           docker run -i --rm \
             --user "$(id -u):$(id -g)" \
             --workdir="$PWD" \
@@ -113,11 +120,12 @@ runs:
             --user "$(id -u):$(id -g)" \
             --workdir="$PWD" \
             -v "$(dirname "$PWD")":"$(dirname "$PWD")" \
-            "$docker_image" bash -c "
+            -e dtb_path="$dtb_path" \
+            "$docker_image" bash -c '
               generate_boot_bins.sh dtb \
-                --input ../kobj/arch/arm64/boot/dts/qcom/$machine.dtb \
+                --input "$dtb_path" \
                 --output images
-            "
+            '
 
           if [ "$rootfs" = "glymur-crd" ]; then
             cp "$build_dir/images/efi_with_dtb.bin" "$build_dir/images/efi.bin"

--- a/.github/actions/loading/action.yml
+++ b/.github/actions/loading/action.yml
@@ -77,7 +77,7 @@ runs:
           const rootfs_matrix = Object.values(targets)
             .filter(({ rootfs }) => rootfs && rootfs.trim() !== '')
             .filter(({ branches }) => !branch || !branches || branches.includes(branch))
-            .map(({ machine, rootfs, firmwareid, lavaname, flash_type }) => ({ machine, rootfs, firmwareid, lavaname, flash_type }));
+            .map(({ machine, rootfs, firmwareid, lavaname, flash_type, hypervisor }) => ({ machine, rootfs, firmwareid, lavaname, flash_type, hypervisor }));
           core.setOutput('rootfs_matrix', JSON.stringify(rootfs_matrix));
           console.log("Rootfs Matrix:", rootfs_matrix);
 

--- a/ci/MACHINES.json
+++ b/ci/MACHINES.json
@@ -8,6 +8,7 @@
     "firmwareid": "rb3gen2",
     "rootfs": "rb3gen2-core-kit",
     "flash_type": "qdl",
+    "hypervisor": "gunyah",
     "branches": ["qcom-next-staging", "qcom-6.18.y", "tech/mproc/rpmsg", "tech/mproc/all", "tech/net/qrtr", "tech/storage/all", "tech/storage/phy"]
   },
   "qcs9100-ride-r3": {
@@ -19,6 +20,7 @@
     "firmwareid": "sa8775p-ride",
     "rootfs": "qcs9100-ride-sx",
     "flash_type": "qdl",
+    "hypervisor": "kvm",
     "branches": ["qcom-next-staging", "qcom-6.18.y", "tech/mproc/rpmsg", "tech/mproc/all", "tech/net/qrtr", "tech/storage/all", "tech/storage/phy"]
   },
   "qcs8300-ride": {
@@ -30,6 +32,7 @@
     "firmwareid": "qcs8300-ride",
     "rootfs": "qcs8300-ride-sx",
     "flash_type": "qdl",
+    "hypervisor": "kvm",
     "branches": ["qcom-next-staging", "qcom-6.18.y", "tech/mproc/rpmsg", "tech/mproc/all", "tech/net/qrtr", "tech/storage/all", "tech/storage/phy"]
   },
   "sm8750-mtp": {
@@ -41,6 +44,7 @@
     "firmwareid": "sm8750-mtp",
     "rootfs": "sm8750-mtp",
     "flash_type": "qdl",
+    "hypervisor": "gunyah",
     "branches": ["qcom-next-staging", "tech/mproc/rpmsg", "tech/mproc/all", "tech/net/qrtr", "tech/storage/all", "tech/storage/phy"]
   },
   "lemans-evk": {
@@ -52,6 +56,7 @@
     "firmwareid": "sa8775p-ride",
     "rootfs": "iq-9075-evk",
     "flash_type": "qdl",
+    "hypervisor": "kvm",
     "branches": ["qcom-next-staging", "qcom-6.18.y", "tech/mproc/rpmsg", "tech/mproc/all", "tech/net/qrtr", "tech/storage/all", "tech/storage/phy"]
   },
   "monaco-evk": {
@@ -63,6 +68,7 @@
     "firmwareid": "qcs8300-ride",
     "rootfs": "iq-8275-evk",
     "flash_type": "qdl",
+    "hypervisor": "kvm",
     "branches": ["qcom-next-staging", "qcom-6.18.y", "tech/mproc/rpmsg", "tech/mproc/all", "tech/net/qrtr", "tech/storage/all", "tech/storage/phy"]
   },
   "qcs615-adp-air": {
@@ -74,6 +80,7 @@
     "firmwareid": "qcs615-ride",
     "rootfs": "qcs615-ride",
     "flash_type": "qdl",
+    "hypervisor": "gunyah",
     "branches": ["qcom-next-staging", "qcom-6.18.y", "tech/mproc/rpmsg", "tech/mproc/all", "tech/net/qrtr", "tech/storage/all", "tech/storage/phy"]
   },
   "kaanapali-mtp": {
@@ -85,6 +92,7 @@
     "firmwareid": "kaanapali-mtp",
     "rootfs": "kaanapali-mtp",
     "flash_type": "qdl",
+    "hypervisor": "gunyah",
     "branches": ["qcom-next-staging"]
   },
   "hamoa-iot-evk": {
@@ -96,6 +104,7 @@
     "firmwareid": "iq-x7181-evk",
     "rootfs": "iq-x7181-evk",
     "flash_type": "qdl",
+    "hypervisor": "gunyah",
     "branches": ["qcom-next-staging", "qcom-6.18.y", "tech/mproc/rpmsg", "tech/mproc/all", "tech/net/qrtr", "tech/storage/all", "tech/storage/phy"]
   },
   "glymur-crd": {
@@ -107,6 +116,7 @@
     "firmwareid": "glymur-crd",
     "rootfs": "glymur-crd",
     "flash_type": "qdl",
+    "hypervisor": "gunyah",
     "branches": ["qcom-next-staging"]
   },
   "qrb2210-rb1": {
@@ -118,6 +128,7 @@
     "firmwareid": "rb1",
     "rootfs": "rb1-core-kit",
     "flash_type": "qdl",
+    "hypervisor": "gunyah",
     "branches": ["qcom-next-staging"]
   }
 }


### PR DESCRIPTION
Describe the hypervisor used by each machine in the CI target data and carry that field through rootfs matrix generation.

Use the value when generating flat meta DTB images so KVM targets package the EL2 DTB while other targets keep using the default board DTB.