### PR TITLE
ci: build_yocto: avoid lock config during kas build

### DIFF
--- a/.github/actions/build_yocto/action.yml
+++ b/.github/actions/build_yocto/action.yml
@@ -220,7 +220,11 @@ runs:
       run: |
         cd ${{ env.build_dir }}
         echo "In build : lock_arg : ${{ env.lock_arg }}"
-        $KAS_CONTAINER build ${{ env.CI_YAML_DIR }}/${{ env.rootfs }}.yml:${{ env.CI_YAML_DIR }}/qcom-distro.yml:${{ env.CI_YAML_DIR }}/kernel-override.yml${{ env.lock_arg }}${{ env.pr_override_arg }}
+        kas_build_args=()
+        if [[ "${{ env.base }}" != "tip" ]]; then
+          kas_build_args+=(--skip repos_checkout --skip repos_apply_patches)
+        fi
+        $KAS_CONTAINER build "${kas_build_args[@]}" ${{ env.CI_YAML_DIR }}/${{ env.rootfs }}.yml:${{ env.CI_YAML_DIR }}/qcom-distro.yml:${{ env.CI_YAML_DIR }}/kernel-override.yml${{ env.pr_override_arg }}
 
         if [[ "${{ env.kernel_ver }}" == "6.18" ]]; then
           recipe="linux-qcom"


### PR DESCRIPTION
Non-tip Yocto builds already check out meta-qcom through the meta-qcom-buildconf lock file before running the build.

Skip repository checkout and patch application for those builds, and leave lock.yml out of the kas build configuration stack. This keeps the build from reprocessing the locked repository state while still allowing PR override configuration to be layered into the build.