### PR TITLE
ci: build_yocto: avoid lock config for kernel version

### DIFF
--- a/.github/actions/build_yocto/action.yml
+++ b/.github/actions/build_yocto/action.yml
@@ -232,7 +232,7 @@ runs:
           recipe="linux-qcom-next"
         fi
 
-        raw_ver=$($KAS_CONTAINER shell ${{ env.CI_YAML_DIR }}/${{ env.rootfs }}.yml:${{ env.CI_YAML_DIR }}/qcom-distro.yml:${{ env.CI_YAML_DIR }}/kernel-override.yml${{ env.lock_arg }}${{ env.pr_override_arg }} -c "bitbake -e $recipe | grep '^KERNEL_VERSION='" | cut -d'"' -f2)
+        raw_ver=$($KAS_CONTAINER shell ${{ env.CI_YAML_DIR }}/${{ env.rootfs }}.yml:${{ env.CI_YAML_DIR }}/qcom-distro.yml:${{ env.CI_YAML_DIR }}/kernel-override.yml${{ env.pr_override_arg }} -c "bitbake -e $recipe | grep '^KERNEL_VERSION='" | cut -d'"' -f2)
         echo "raw_kernel_version=$raw_ver" >> $GITHUB_ENV
 
     - name: Get Kernel Version


### PR DESCRIPTION
The Yocto build no longer layers lock.yml into the kas build command, but the follow-up kas shell call still used the lock config when reading KERNEL_VERSION.

Drop lock.yml from that command as well so the version query uses the same configuration stack as the build.