### PR TITLE
Revert "ci: Use staging branch for CI in case of topic branches."

### DIFF
--- a/.github/actions/sync/action.yml
+++ b/.github/actions/sync/action.yml
@@ -134,7 +134,7 @@ runs:
       shell: bash
       run: |
         TOPIC_BRANCH=${{ inputs.base_branch }}
-        echo "baseline https://github.com/qualcomm-linux/kernel.git qcom-next-staging-topics" > merge.conf
+        echo "baseline https://github.com/qualcomm-linux/kernel.git qcom-next" > merge.conf
         while IFS=',' read -r pr_number topic_branch; do
           echo "$topic_branch https://github.com/qualcomm-linux/kernel-topics.git $topic_branch" >> merge.conf
         done < topic-branches


### PR DESCRIPTION
Use qcom-next as the base for CI

This reverts commit 88a53638aead2a897ab3d4eb7fb7e62c88bb947b.