### PR TITLE
ci: Add storage handling for flat meta generation

### DIFF
--- a/.github/actions/flat_meta_generation/action.yml
+++ b/.github/actions/flat_meta_generation/action.yml
@@ -32,11 +32,13 @@ runs:
           rootfs=$(echo "$row" | jq -r '.rootfs')
           firmwareid=$(echo "$row" | jq -r '.firmwareid')
           hypervisor=$(echo "$row" | jq -r '.hypervisor // ""')
+          storage=$(echo "$row" | jq -r '.storage // "ufs"')
 
           echo "Target : $machine"
           echo "Rootfs ID : $rootfs"
           echo "Firmware ID : $firmwareid"
           echo "Hypervisor : $hypervisor"
+          echo "Storage : $storage"
           echo "-----------------------------"
 
           if [ -z "$rootfs" ]; then
@@ -163,5 +165,12 @@ runs:
 
           cp "$build_dir/images/efi.bin" "$meta_dir"
           cp "$build_dir/images/dtb.bin" "$meta_dir"
+          if [ "$storage" = "spinor" ]; then
+            if [ -d "$meta_dir/spinor" ]; then
+              cp "$build_dir/images/dtb.bin" "$meta_dir/spinor/dtb.bin"
+            else
+              echo "spinor directory not present for $machine, skip copying dtb.bin."
+            fi
+          fi
           tar -czvf "$workspace/qcom-multimedia-image-${rootfs}.rootfs.qcomflash.tar.gz" "qcom-multimedia-image-${rootfs}.rootfs.qcomflash/"
         done

--- a/.github/actions/loading/action.yml
+++ b/.github/actions/loading/action.yml
@@ -77,7 +77,15 @@ runs:
           const rootfs_matrix = Object.values(targets)
             .filter(({ rootfs }) => rootfs && rootfs.trim() !== '')
             .filter(({ branches }) => !branch || !branches || branches.includes(branch))
-            .map(({ machine, rootfs, firmwareid, lavaname, flash_type, hypervisor }) => ({ machine, rootfs, firmwareid, lavaname, flash_type, hypervisor }));
+            .map(({ machine, rootfs, firmwareid, lavaname, flash_type, hypervisor, storage }) => ({
+              machine,
+              rootfs,
+              firmwareid,
+              lavaname,
+              flash_type,
+              hypervisor,
+              storage: storage || 'ufs'
+            }));
           core.setOutput('rootfs_matrix', JSON.stringify(rootfs_matrix));
           console.log("Rootfs Matrix:", rootfs_matrix);
 

--- a/ci/MACHINES.json
+++ b/ci/MACHINES.json
@@ -8,6 +8,7 @@
     "firmwareid": "rb3gen2",
     "rootfs": "rb3gen2-core-kit",
     "flash_type": "qdl",
+    "storage": "ufs",
     "hypervisor": "gunyah",
     "branches": ["qcom-next-staging", "qcom-6.18.y", "tech/mproc/rpmsg", "tech/mproc/all", "tech/net/qrtr", "tech/storage/all", "tech/storage/phy", "tech/bus/pci/pwrctl", "tech/bus/pci/phy", "tech/bus/pci/mhi", "tech/bus/pci/all", "tech/pmic/supply", "tech/pmic/regulator", "tech/pmic/misc", "tech/pmic/mfd", "tech/pmic/backlight", "tech/bus/usb/phy", "tech/bus/usb/dwc", "tech/bus/usb/gadget", "tech/bsp/clk", "tech/bsp/interconnect"]
   },
@@ -20,6 +21,7 @@
     "firmwareid": "sa8775p-ride",
     "rootfs": "qcs9100-ride-sx",
     "flash_type": "qdl",
+    "storage": "ufs",
     "hypervisor": "kvm",
     "branches": ["qcom-next-staging", "qcom-6.18.y", "tech/mproc/rpmsg", "tech/mproc/all", "tech/net/qrtr", "tech/storage/all", "tech/storage/phy", "tech/bus/pci/pwrctl", "tech/bus/pci/phy", "tech/bus/pci/mhi", "tech/bus/pci/all", "tech/pmic/supply", "tech/pmic/regulator", "tech/pmic/misc", "tech/pmic/mfd", "tech/pmic/backlight", "tech/bus/usb/phy", "tech/bus/usb/dwc", "tech/bus/usb/gadget", "tech/bsp/clk", "tech/bsp/interconnect"]
   },
@@ -32,6 +34,7 @@
     "firmwareid": "qcs8300-ride",
     "rootfs": "qcs8300-ride-sx",
     "flash_type": "qdl",
+    "storage": "ufs",
     "hypervisor": "gunyah",
     "branches": ["qcom-next-staging", "qcom-6.18.y", "tech/mproc/rpmsg", "tech/mproc/all", "tech/net/qrtr", "tech/storage/all", "tech/storage/phy", "tech/bus/pci/pwrctl", "tech/bus/pci/phy", "tech/bus/pci/mhi", "tech/bus/pci/all", "tech/pmic/supply", "tech/pmic/regulator", "tech/pmic/misc", "tech/pmic/mfd", "tech/pmic/backlight", "tech/bus/usb/phy", "tech/bus/usb/dwc", "tech/bus/usb/gadget", "tech/bsp/clk", "tech/bsp/interconnect"]
   },
@@ -44,6 +47,7 @@
     "firmwareid": "sm8750-mtp",
     "rootfs": "sm8750-mtp",
     "flash_type": "qdl",
+    "storage": "ufs",
     "hypervisor": "gunyah",
     "branches": ["qcom-next-staging", "tech/mproc/rpmsg", "tech/mproc/all", "tech/net/qrtr", "tech/storage/all", "tech/storage/phy", "tech/bus/pci/pwrctl", "tech/bus/pci/phy", "tech/bus/pci/mhi", "tech/bus/pci/all", "tech/pmic/supply", "tech/pmic/regulator", "tech/pmic/misc", "tech/pmic/mfd", "tech/pmic/backlight", "tech/bus/usb/phy", "tech/bus/usb/dwc", "tech/bus/usb/gadget", "tech/bsp/clk", "tech/bsp/interconnect"]
   },
@@ -56,6 +60,7 @@
     "firmwareid": "sa8775p-ride",
     "rootfs": "iq-9075-evk",
     "flash_type": "qdl",
+    "storage": "ufs",
     "hypervisor": "kvm",
     "branches": ["qcom-next-staging", "qcom-6.18.y", "tech/mproc/rpmsg", "tech/mproc/all", "tech/net/qrtr", "tech/storage/all", "tech/storage/phy", "tech/bus/pci/pwrctl", "tech/bus/pci/phy", "tech/bus/pci/mhi", "tech/bus/pci/all", "tech/pmic/supply", "tech/pmic/regulator", "tech/pmic/misc", "tech/pmic/mfd", "tech/pmic/backlight", "tech/bus/usb/phy", "tech/bus/usb/dwc", "tech/bus/usb/gadget", "tech/bsp/clk", "tech/bsp/interconnect"]
   },
@@ -68,6 +73,7 @@
     "firmwareid": "qcs8300-ride",
     "rootfs": "iq-8275-evk",
     "flash_type": "qdl",
+    "storage": "ufs",
     "hypervisor": "kvm",
     "branches": ["qcom-next-staging", "qcom-6.18.y", "tech/mproc/rpmsg", "tech/mproc/all", "tech/net/qrtr", "tech/storage/all", "tech/storage/phy", "tech/bus/pci/pwrctl", "tech/bus/pci/phy", "tech/bus/pci/mhi", "tech/bus/pci/all", "tech/pmic/supply", "tech/pmic/regulator", "tech/pmic/misc", "tech/pmic/mfd", "tech/pmic/backlight", "tech/bus/usb/phy", "tech/bus/usb/dwc", "tech/bus/usb/gadget", "tech/bsp/clk", "tech/bsp/interconnect"]
   },
@@ -80,6 +86,7 @@
     "firmwareid": "qcs615-ride",
     "rootfs": "qcs615-ride",
     "flash_type": "qdl",
+    "storage": "ufs",
     "hypervisor": "gunyah",
     "branches": ["qcom-next-staging", "qcom-6.18.y", "tech/mproc/rpmsg", "tech/mproc/all", "tech/net/qrtr", "tech/storage/all", "tech/storage/phy", "tech/bus/pci/pwrctl", "tech/bus/pci/phy", "tech/bus/pci/mhi", "tech/bus/pci/all", "tech/pmic/supply", "tech/pmic/regulator", "tech/pmic/misc", "tech/pmic/mfd", "tech/pmic/backlight", "tech/bus/usb/phy", "tech/bus/usb/dwc", "tech/bus/usb/gadget", "tech/bsp/clk", "tech/bsp/interconnect"]
   },
@@ -92,6 +99,7 @@
     "firmwareid": "kaanapali-mtp",
     "rootfs": "kaanapali-mtp",
     "flash_type": "qdl",
+    "storage": "ufs",
     "hypervisor": "gunyah",
     "branches": ["qcom-next-staging", "tech/pmic/supply", "tech/pmic/regulator", "tech/pmic/misc", "tech/pmic/mfd", "tech/pmic/backlight", "tech/bus/usb/phy", "tech/bus/usb/dwc", "tech/bus/usb/gadget", "tech/bsp/clk", "tech/bsp/interconnect"]
   },
@@ -104,6 +112,7 @@
     "firmwareid": "iq-x7181-evk",
     "rootfs": "iq-x7181-evk",
     "flash_type": "qdl",
+    "storage": "spinor",
     "hypervisor": "gunyah",
     "branches": ["qcom-next-staging", "qcom-6.18.y", "tech/mproc/rpmsg", "tech/mproc/all", "tech/net/qrtr", "tech/storage/all", "tech/storage/phy", "tech/bus/pci/pwrctl", "tech/bus/pci/phy", "tech/bus/pci/mhi", "tech/bus/pci/all", "tech/pmic/supply", "tech/pmic/regulator", "tech/pmic/misc", "tech/pmic/mfd", "tech/pmic/backlight", "tech/bus/usb/phy", "tech/bus/usb/dwc", "tech/bus/usb/gadget", "tech/bsp/clk", "tech/bsp/interconnect"]
   },
@@ -116,6 +125,7 @@
     "firmwareid": "glymur-crd",
     "rootfs": "glymur-crd",
     "flash_type": "qdl",
+    "storage": "spinor",
     "hypervisor": "gunyah",
     "branches": ["qcom-next-staging", "tech/pmic/supply", "tech/pmic/regulator", "tech/pmic/misc", "tech/pmic/mfd", "tech/pmic/backlight", "tech/bus/usb/phy", "tech/bus/usb/dwc", "tech/bus/usb/gadget", "tech/bsp/clk", "tech/bsp/interconnect"]
   },
@@ -128,6 +138,7 @@
     "firmwareid": "rb1",
     "rootfs": "rb1-core-kit",
     "flash_type": "qdl",
+    "storage": "ufs",
     "hypervisor": "gunyah",
     "branches": ["qcom-next-staging", "tech/pmic/supply", "tech/pmic/regulator", "tech/pmic/misc", "tech/pmic/mfd", "tech/pmic/backlight", "tech/bus/usb/phy", "tech/bus/usb/dwc", "tech/bus/usb/gadget", "tech/bsp/clk", "tech/bsp/interconnect"]
   }


### PR DESCRIPTION
For SPI-NOR targets, copy dtb.bin into the existing spinor directory when the extracted qcomflash package provides one, while keeping the default UFS flow unchanged.

This is needed as for spinor targets dtb.bin is picked from spinor, instead of ufs/nvme.