### PR TITLE
ci: Include vmlinux in flatbuild images

### DIFF
--- a/.github/actions/flat_meta_generation/action.yml
+++ b/.github/actions/flat_meta_generation/action.yml
@@ -165,6 +165,7 @@ runs:
 
           cp "$build_dir/images/efi.bin" "$meta_dir"
           cp "$build_dir/images/dtb.bin" "$meta_dir"
+          cp "$workspace/../kobj/vmlinux" "$meta_dir"
           if [ "$storage" = "spinor" ]; then
             if [ -d "$meta_dir/spinor" ]; then
               cp "$build_dir/images/dtb.bin" "$meta_dir/spinor/dtb.bin"


### PR DESCRIPTION
Copy vmlinux into the generated qcomflash directory before the flatbuild tarball is created.

This keeps the debug symbol image available alongside efi.bin and dtb.bin in the packaged flatbuild output.