### PR TITLE
qcom-next.conf: add eliza topic dt branch

### DIFF
--- a/qcom-next.conf
+++ b/qcom-next.conf
@@ -59,6 +59,7 @@ tech/all/dt/qcs9100        https://github.com/qualcomm-linux/kernel-topics.git  
 tech/all/dt/qcs8300        https://github.com/qualcomm-linux/kernel-topics.git       tech/all/dt/qcs8300
 tech/all/dt/qcs615         https://github.com/qualcomm-linux/kernel-topics.git       tech/all/dt/qcs615
 tech/all/dt/agatti         https://github.com/qualcomm-linux/kernel-topics.git       tech/all/dt/agatti
+tech/all/dt/eliza          https://github.com/qualcomm-linux/kernel-topics.git       tech/all/dt/eliza
 tech/all/dt/hamoa          https://github.com/qualcomm-linux/kernel-topics.git       tech/all/dt/hamoa
 tech/all/dt/glymur         https://github.com/qualcomm-linux/kernel-topics.git       tech/all/dt/glymur
 tech/all/dt/kaanapali      https://github.com/qualcomm-linux/kernel-topics.git       tech/all/dt/kaanapali


### PR DESCRIPTION
Add eliza dt topic branches to qcom-next.conf.