### PR TITLE
ci: Pass secrets to kernel checker workflow

### DIFF
--- a/.github/workflows/kernel_checker.yml
+++ b/.github/workflows/kernel_checker.yml
@@ -36,6 +36,7 @@ jobs:
   checker:
     needs: [init-status]
     uses: qualcomm-linux/kernel-checkers/.github/workflows/checker.yml@main
+    inherit: secrets
     with:
       check_name: ${{ matrix.check }}
       base_branch: ${{ inputs.ref }}


### PR DESCRIPTION
Allow the reusable kernel checker workflow to receive repository secrets when it is invoked from kernel_checker.yml.