### PR TITLE
ci: Run Yocto LAVA tests for both image configs

### DIFF
--- a/.github/actions/lava_job_render/action.yml
+++ b/.github/actions/lava_job_render/action.yml
@@ -21,6 +21,10 @@ inputs:
   build_type:
     description: Build type kbdev/Yocto
     required: false
+  image_type:
+    description: "Yocto qcomflash image type: multimedia or proprietary"
+    required: false
+    default: multimedia
 
 runs:
   using: "composite"
@@ -30,13 +34,16 @@ runs:
       uses: actions/github-script@v7
       env:
         FLASH_TYPE: ${{ inputs.flash_type }}
+        IMAGE_TYPE: ${{ inputs.image_type }}
       with:
         script: |
           const fs = require('fs');
           const p = require('path');
 
           const flashType = (process.env.FLASH_TYPE || 'qdl').toLowerCase();
+          const imageType = (process.env.IMAGE_TYPE || 'multimedia').toLowerCase();
           console.log(`Flash type: ${flashType}`);
+          console.log(`Image type: ${imageType}`);
           // Helper function to find URL by filename
           function findUrlByFilename(filename) {
             for (const [path, url] of Object.entries(data)) {
@@ -78,9 +85,21 @@ runs:
 
             const dtbFilename = `${process.env.MACHINE}.dtb`;
             const dtbUrl = findUrlByFilename(dtbFilename);
-            rootfs_name = `qcom-multimedia-image-${process.env.rootfs}.rootfs.qcomflash.tar.gz`;
+            let rootfs_name;
+            if (imageType === 'proprietary') {
+              rootfs_name = `qcom-multimedia-proprietary-image-${process.env.rootfs}.rootfs.qcomflash.tar.gz`;
+            } else if (imageType === 'multimedia') {
+              rootfs_name = `qcom-multimedia-image-${process.env.rootfs}.rootfs.qcomflash.tar.gz`;
+            } else {
+              core.setFailed(`Invalid image_type '${imageType}'. Allowed: multimedia, proprietary`);
+              return;
+            }
             core.setOutput('rootfs_name', rootfs_name);
             const rootfsurl = findUrlByFilename(rootfs_name);
+            if (!rootfsurl) {
+              core.setFailed(`URL not found in presigned_urls.json for ${rootfs_name}`);
+              return;
+            }
 
             core.setOutput('rootfsurl', rootfsurl);
             core.setOutput('dtb_url', dtbUrl);
@@ -121,6 +140,7 @@ runs:
       env:
         FLASH_TYPE: ${{ inputs.flash_type }}
         BUILD_TYPE: ${{ inputs.build_type }}
+        IMAGE_TYPE: ${{ inputs.image_type }}
       run: |
         flash_type="${FLASH_TYPE:-qdl}"
         flash_type="$(echo "$flash_type" | tr '[:upper:]' '[:lower:]')"
@@ -129,6 +149,10 @@ runs:
         build_type="${BUILD_TYPE:-yocto}"
         build_type="$(echo "$build_type" | tr '[:upper:]' '[:lower:]')"
         echo "Build type: $build_type"
+
+        image_type="${IMAGE_TYPE:-multimedia}"
+        image_type="$(echo "$image_type" | tr '[:upper:]' '[:lower:]')"
+        echo "Image type: $image_type"
 
         major=$(echo "${{ inputs.kernel_version }}" | cut -d. -f1)
         patchlevel=$(echo "${{ inputs.kernel_version }}" | cut -d. -f2 | cut -d- -f1)
@@ -152,12 +176,13 @@ runs:
           -e extra="$extra" \
           -e branch="${{ inputs.branch }}" \
           -e pr_number="${{ inputs.pr_number }}" \
+          -e image_type="$image_type" \
           ${{ inputs.docker_image }} \
           jq '
               .artifacts.metadata = env.metadata_url
             | .id = env.commit_SHA
-            | .name = "kernel-qli"
-            | .data.kernel_revision.describe = ("PR:"+env.pr_number + ", Branch:" + env.branch + ", Kernel Version:" + env.kernel_version)
+            | .name = (if env.image_type == "proprietary" then "kernel-qli-proprietary" else "kernel-qli" end)
+            | .data.kernel_revision.describe = ("PR:"+env.pr_number + ", Branch:" + env.branch + ", Kernel Version:" + env.kernel_version + ", Image:" + env.image_type)
             | .data.kernel_revision.commit_tags = [env.commit_tag]
             | .data.kernel_revision.commit = env.commit_SHA
             | .data.kernel_revision.version.version = (env.major | tonumber)
@@ -236,13 +261,24 @@ runs:
       shell: bash
       env:
         FLASH_TYPE: ${{ inputs.flash_type }}
+        BUILD_TYPE: ${{ inputs.build_type }}
+        IMAGE_TYPE: ${{ inputs.image_type }}
       run: |
         cd ../job_render
         mkdir -p renders
+        rm -f renders/lava_job_definition*.yaml
 
         flash_type="${FLASH_TYPE:-qdl}"
         flash_type="$(echo "$flash_type" | tr '[:upper:]' '[:lower:]')"
         echo "Flash type: $flash_type"
+
+        build_type="${BUILD_TYPE:-yocto}"
+        build_type="$(echo "$build_type" | tr '[:upper:]' '[:lower:]')"
+        echo "Build type: $build_type"
+
+        image_type="${IMAGE_TYPE:-multimedia}"
+        image_type="$(echo "$image_type" | tr '[:upper:]' '[:lower:]')"
+        echo "Image type: $image_type"
 
         if [[ "$flash_type" == "fastboot" ]]; then
           export TARGET="${{ env.LAVA_NAME }}"
@@ -253,8 +289,12 @@ runs:
           python3 lava_Job_definition_generator.py --localjson ./data/cloudData.json --qcom-next-ci-premerge
         elif [[ "$flash_type" == "qdl" ]]; then
           EXTRA_ARGS=""
-          if [[ "${{ inputs.build_type }}" == "yocto" ]]; then
-            EXTRA_ARGS="--meta-qcom_PreMerge --meta-qcom"
+          if [[ "$build_type" == "yocto" ]]; then
+            if [[ "$image_type" == "proprietary" ]]; then
+              EXTRA_ARGS="--meta-qcom-nightly_config2 --meta-qcom"
+            else
+              EXTRA_ARGS="--meta-qcom-nightly_config1 --meta-qcom"
+            fi
           else
             EXTRA_ARGS="--qcom-next-ci-premerge"
           fi

--- a/.github/workflows/post-merge-yocto.yml
+++ b/.github/workflows/post-merge-yocto.yml
@@ -94,6 +94,10 @@ jobs:
 
   test:
     needs: [init-status, loading, build_yocto]
+    strategy:
+      fail-fast: false
+      matrix:
+        image_type: [multimedia, proprietary]
     uses: qualcomm-linux/kernel-config/.github/workflows/test.yml@main
     secrets: inherit
     with:
@@ -105,7 +109,7 @@ jobs:
       pr_number: "tip"
       flash_type: "qdl"
       build_type: "yocto"
-
+      image_type: ${{ matrix.image_type }}
 
   nightly_report:
     name: Nightly Test Report

--- a/.github/workflows/pre-merge-yocto.yml
+++ b/.github/workflows/pre-merge-yocto.yml
@@ -92,17 +92,36 @@ jobs:
           APPID: ${{ secrets.APPID }}
           PVK: ${{ secrets.PVK }}
 
+  test:
+    needs: [init-status, loading, build_yocto]
+    strategy:
+      fail-fast: false
+      matrix:
+        image_type: [multimedia, proprietary]
+    uses: qualcomm-linux/kernel-config/.github/workflows/test.yml@main
+    secrets: inherit
+    with:
+      docker_image: ${{ vars.TECH_TEAM_NAMESPACE }}/kmake-image:${{ vars.KMAKE_IMAGE_VERSION }}
+      rootfs_matrix: ${{ needs.loading.outputs.rootfs_matrix }}
+      kernel_version: ${{ needs.build_yocto.outputs.kernel_version }}
+      commit_SHA: ${{ inputs.sha }}
+      branch: ${{ inputs.ref }}
+      pr_number: ${{ inputs.pr }}
+      flash_type: "qdl"
+      build_type: "yocto"
+      image_type: ${{ matrix.image_type }}
+
   final-status:
     name: Finalize Status
     if: always()
     runs-on: ubuntu-latest
-    needs: [build_yocto, check_run]
+    needs: [build_yocto, check_run, test]
     steps:
       - name: Set final status
         uses: qualcomm-linux/kernel-config/.github/actions/workflow_status@main
         with:
           sha: ${{ github.event.inputs.sha || github.sha }}
-          action_mode: ${{ needs.build_yocto.result }}
+          action_mode: ${{ needs.build_yocto.result == 'success' && needs.test.result || needs.build_yocto.result }}
           check_name: "Yocto Build Generation"
           repo: ${{ github.event.inputs.repo || github.repository }}
           GH_TOKEN: ${{ secrets.PAT }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,8 +44,15 @@ on:
         type: string
         required: true
 
+      image_type:
+        description: Yocto qcomflash image type
+        type: string
+        required: false
+        default: multimedia
+
 jobs:
   test:
+    name: Test ${{ matrix.rootfs_matrix.machine }} ${{ inputs.image_type }}
     runs-on:
       group: GHA-Kernel-SelfHosted-RG
       labels: [ self-hosted, kernel-prd-u2404-x64-large-od-ephem ]
@@ -108,6 +115,7 @@ jobs:
           pr_number: ${{ inputs.pr_number }}
           flash_type: ${{ steps.flash.outputs.flash_type }}
           build_type: ${{ inputs.build_type }}
+          image_type: ${{ inputs.image_type }}
         env:
           FIRMWARE: ${{ matrix.rootfs_matrix.firmwareid }}
           MACHINE: ${{ matrix.rootfs_matrix.machine }}
@@ -206,6 +214,7 @@ jobs:
         run: |
           set -e
           MACHINE="${{ matrix.rootfs_matrix.machine }}"
+          IMAGE_TYPE="${{ inputs.image_type }}"
           SUITE_NAME="LAVA-${MACHINE}"
           IN="results.json"
 
@@ -228,7 +237,7 @@ jobs:
                       name: .name,
                       result: .result
                   })
-              ' "$IN" > lava-results/Tests-${MACHINE}.json
+              ' "$IN" > "lava-results/Tests-${MACHINE}-${IMAGE_TYPE}.json"
 
       - name: Update summary
         if: success() || failure()
@@ -252,19 +261,19 @@ jobs:
           </details>
           '
           echo -e "$SUMMARY" >> $GITHUB_STEP_SUMMARY
-          JOB_INFO="- [Job $job_id on ${{ matrix.rootfs_matrix.machine }}]($job_url)"
+          JOB_INFO="- [${{ inputs.image_type }} Job $job_id on ${{ matrix.rootfs_matrix.machine }}]($job_url)"
           echo -e "$JOB_INFO" > job_info.md
 
       - name: Upload Job Info Artifacts
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: job_info_${{ matrix.rootfs_matrix.machine }}
+          name: job_info_${{ matrix.rootfs_matrix.machine }}_${{ inputs.image_type }}
           path: job_info.md
 
       - name: Upload Lava Json File
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: Tests-${{ matrix.rootfs_matrix.machine }}
+          name: Tests-${{ matrix.rootfs_matrix.machine }}-${{ inputs.image_type }}
           path: lava-results/*.json


### PR DESCRIPTION
Add image_type plumbing so LAVA job rendering can select the multimedia or proprietary qcomflash artifact and use the matching config1/config2 playlist.

Run both image types for pre-merge and post-merge Yocto tests, and include the image type in job names and test artifacts to avoid result collisions.