### PR TITLE
ci: Add LAVA report links for Yocto tests

### DIFF
--- a/.github/workflows/comment.yml
+++ b/.github/workflows/comment.yml
@@ -44,7 +44,7 @@ jobs:
           -H "Accept: application/vnd.github+json" \
           -H "Authorization: Bearer ${{ secrets.PAT }}" \
           -H "X-GitHub-Api-Version: 2022-11-28" \
-          https://api.github.com/repos/${{ inputs.repo }}/issues/${{ inputs.pr }}/comments \
+          https://api.github.com/repos/${{ inputs.repo }}/issues/${{ inputs.pr_number }}/comments \
           -d "$json" 
 
   publish:
@@ -146,8 +146,6 @@ jobs:
 
       - name: Post results to PR
         run: |
-          #echo '${{ steps.publish_test.outputs.json }}' > test-results.json
-          #CONTENT=$(jq -Rs . < test-results.json)
           DATA=$(jq -n --rawfile body summary.md '{body: $body}')
 
           curl -L \
@@ -155,5 +153,5 @@ jobs:
           -H "Accept: application/vnd.github+json" \
           -H "Authorization: Bearer ${{ secrets.PAT }}" \
           -H "X-GitHub-Api-Version: 2022-11-28" \
-          https://api.github.com/repos/${{ inputs.repo }}/issues/${{ inputs.pr }}/comments \
+          https://api.github.com/repos/${{ inputs.repo }}/issues/${{ inputs.pr_number }}/comments \
           -d "$DATA"

--- a/.github/workflows/post-merge-yocto.yml
+++ b/.github/workflows/post-merge-yocto.yml
@@ -141,6 +141,18 @@ jobs:
           commit_url="https://github.com/${{ inputs.repo }}/commit/${sha}"
           run_url="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
+          declare -A JOB_URLS=()
+          if ls job-info/*.md 1>/dev/null 2>&1; then
+            while IFS= read -r line; do
+              if [[ "$line" =~ ^-\ \[([^[:space:]]+)\ Job\ [^]]+\ on\ ([^]]+)\]\(([^)]+)\) ]]; then
+                image_type="${BASH_REMATCH[1]}"
+                machine="${BASH_REMATCH[2]}"
+                job_url="${BASH_REMATCH[3]}"
+                JOB_URLS["${machine}-${image_type}"]="$job_url"
+              fi
+            done < <(cat job-info/*.md)
+          fi
+
           {
             echo "# Nightly LAVA Test Report"
             echo ""
@@ -170,7 +182,13 @@ jobs:
               TESTS=$(jq -r '.[].name' "${FILES[@]}" | sort -u)
 
               printf "| Test Case "
-              for t in "${TARGETS[@]}"; do printf "| %s " "$t"; done
+              for t in "${TARGETS[@]}"; do
+                target_label="$t"
+                if [ -n "${JOB_URLS[$t]:-}" ]; then
+                  target_label="[$t](${JOB_URLS[$t]})"
+                fi
+                printf "| %s " "$target_label"
+              done
               printf "|\n"
 
               printf "| --- "

--- a/.github/workflows/pre-merge-yocto.yml
+++ b/.github/workflows/pre-merge-yocto.yml
@@ -111,6 +111,129 @@ jobs:
       build_type: "yocto"
       image_type: ${{ matrix.image_type }}
 
+  premerge_report:
+    name: Pre-merge LAVA Test Report
+    if: always()
+    needs: [test]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download all test JSON artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: Tests-*
+          path: all-json
+          merge-multiple: true
+
+      - name: Download all job info artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: job_info_*
+          path: job-info
+          merge-multiple: true
+
+      - name: Generate report
+        run: |
+          set -e
+          INPUT_DIR="all-json"
+
+          sha="${{ inputs.sha }}"
+          short_sha="${sha:0:7}"
+          commit_url="https://github.com/${{ inputs.repo }}/commit/${sha}"
+          pr_url="https://github.com/${{ inputs.repo }}/pull/${{ inputs.pr }}"
+          run_url="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+          declare -A JOB_URLS=()
+          if ls job-info/*.md 1>/dev/null 2>&1; then
+            while IFS= read -r line; do
+              if [[ "$line" =~ ^-\ \[([^[:space:]]+)\ Job\ [^]]+\ on\ ([^]]+)\]\(([^)]+)\) ]]; then
+                image_type="${BASH_REMATCH[1]}"
+                machine="${BASH_REMATCH[2]}"
+                job_url="${BASH_REMATCH[3]}"
+                JOB_URLS["${machine}-${image_type}"]="$job_url"
+              fi
+            done < <(cat job-info/*.md)
+          fi
+
+          {
+            echo "# Pre-merge LAVA Test Report"
+            echo ""
+            echo "| | |"
+            echo "| --- | --- |"
+            echo "| **Pull Request** | [#${{ inputs.pr }}](${pr_url}) |"
+            echo "| **Branch** | \`${{ inputs.ref }}\` |"
+            echo "| **Commit** | [\`${short_sha}\`](${commit_url}) |"
+            echo "| **Run** | [${run_url}](${run_url}) |"
+            echo ""
+
+            if ls job-info/*.md 1>/dev/null 2>&1; then
+              echo "## LAVA Jobs"
+              cat job-info/*.md
+              echo ""
+            fi
+
+            mapfile -t FILES < <(ls "$INPUT_DIR"/*.json 2>/dev/null || true)
+            if [ ${#FILES[@]} -gt 0 ]; then
+              echo "## Test Matrix"
+              echo ""
+
+              TARGETS=()
+              for f in "${FILES[@]}"; do
+                TARGETS+=("$(basename "$f" .json | sed 's/^Tests-//')")
+              done
+
+              TESTS=$(jq -r '.[].name' "${FILES[@]}" | sort -u)
+
+              printf "| Test Case "
+              for t in "${TARGETS[@]}"; do
+                target_label="$t"
+                if [ -n "${JOB_URLS[$t]:-}" ]; then
+                  target_label="[$t](${JOB_URLS[$t]})"
+                fi
+                printf "| %s " "$target_label"
+              done
+              printf "|\n"
+
+              printf "| --- "
+              for _ in "${TARGETS[@]}"; do printf "| :---: "; done
+              printf "|\n"
+
+              while IFS= read -r test; do
+                printf "| %s " "$test"
+                for t in "${TARGETS[@]}"; do
+                  res=$(jq -r --arg n "$test" '.[] | select(.name==$n) | .result' "$INPUT_DIR/Tests-${t}.json" 2>/dev/null || true)
+                  case "$res" in
+                    pass)  cell="✅" ;;
+                    fail)  cell="❌" ;;
+                    skip)  cell="⚠️" ;;
+                    error) cell="⛔" ;;
+                    *)     cell="➖" ;;
+                  esac
+                  printf "| %s " "$cell"
+                done
+                printf "|\n"
+              done <<< "$TESTS"
+
+              echo ""
+              echo "## Summary"
+              echo ""
+              printf "| Target | ✅ Pass | ❌ Fail | ⚠️ Skip | Total |\n"
+              printf "| --- | :---: | :---: | :---: | :---: |\n"
+              for t in "${TARGETS[@]}"; do
+                f="$INPUT_DIR/Tests-${t}.json"
+                total=$(jq 'length' "$f" 2>/dev/null || echo 0)
+                total="${total:-0}"
+                if [ "$total" -eq 0 ]; then
+                  printf "| %s | ➖ | ➖ | ➖ | N/A (Incomplete) |\n" "$t"
+                else
+                  pass=$(jq '[.[] | select(.result=="pass")] | length' "$f")
+                  fail=$(jq '[.[] | select(.result=="fail")] | length' "$f")
+                  skip=$(jq '[.[] | select(.result=="skip")] | length' "$f")
+                  printf "| %s | %s | %s | %s | %s |\n" "$t" "$pass" "$fail" "$skip" "$total"
+                fi
+              done
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
   final-status:
     name: Finalize Status
     if: always()


### PR DESCRIPTION
Generate a pre-merge Yocto LAVA report on the
workflow summary and link test matrix columns to their LAVA jobs.

Apply the same matrix job links to post-merge reports and fix comment workflow PR posting to use the pr_number input.