### PR TITLE
ci: Fix Yocto LAVA report job parsing

### DIFF
--- a/.github/workflows/post-merge-yocto.yml
+++ b/.github/workflows/post-merge-yocto.yml
@@ -142,9 +142,10 @@ jobs:
           run_url="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
           declare -A JOB_URLS=()
+          job_info_re='^- \[([^[:space:]]+) Job [^]]+ on ([^]]+)\]\(([^)]*)\)'
           if ls job-info/*.md 1>/dev/null 2>&1; then
             while IFS= read -r line; do
-              if [[ "$line" =~ ^-\ \[([^[:space:]]+)\ Job\ [^]]+\ on\ ([^]]+)\]\(([^)]+)\) ]]; then
+              if [[ "$line" =~ $job_info_re ]]; then
                 image_type="${BASH_REMATCH[1]}"
                 machine="${BASH_REMATCH[2]}"
                 job_url="${BASH_REMATCH[3]}"

--- a/.github/workflows/pre-merge-yocto.yml
+++ b/.github/workflows/pre-merge-yocto.yml
@@ -143,9 +143,10 @@ jobs:
           run_url="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
           declare -A JOB_URLS=()
+          job_info_re='^- \[([^[:space:]]+) Job [^]]+ on ([^]]+)\]\(([^)]*)\)'
           if ls job-info/*.md 1>/dev/null 2>&1; then
             while IFS= read -r line; do
-              if [[ "$line" =~ ^-\ \[([^[:space:]]+)\ Job\ [^]]+\ on\ ([^]]+)\]\(([^)]+)\) ]]; then
+              if [[ "$line" =~ $job_info_re ]]; then
                 image_type="${BASH_REMATCH[1]}"
                 machine="${BASH_REMATCH[2]}"
                 job_url="${BASH_REMATCH[3]}"


### PR DESCRIPTION
Move the job-info markdown regex into a variable before using it with Bash's =~ operator. This avoids shell parsing errors on literal parentheses and lets the pre/post Yocto report jobs generate summaries with linked LAVA jobs.