### PR TITLE
ci: Streamline Yocto workflow summaries

### DIFF
--- a/.github/actions/build_yocto/action.yml
+++ b/.github/actions/build_yocto/action.yml
@@ -280,21 +280,3 @@ runs:
         mode: multi-upload
       env:
         machine: ${{ inputs.rootfs }}_
-
-    - name: Update Summary
-      if: always()
-      shell: bash
-      run: |
-        if [ "${{ steps.upload_artifacts.outcome }}" == "success" ]; then
-          status="Success"
-          emoji=":heavy_check_mark:"
-        else
-          status="Failure"
-          emoji=":x:"
-        fi
-        echo "### Build completed successfully." >> $GITHUB_STEP_SUMMARY
-        echo "- Artifacts upload to AWS s3 location: **$status** $emoji" >> $GITHUB_STEP_SUMMARY
-        echo "- Build logs upload to AWS s3 location: **$status** $emoji" >> $GITHUB_STEP_SUMMARY
-        if [ $status == "Success" ]; then
-          echo "- Check github artifacts for presigned URLs JSON file containing link to the logs and artifacts." >> $GITHUB_STEP_SUMMARY
-        fi

--- a/.github/workflows/post-merge-yocto.yml
+++ b/.github/workflows/post-merge-yocto.yml
@@ -21,7 +21,7 @@ on:
         description: base build or tip
         type: string
         default: tip
-        required: true
+        required: false
       pr_list:
         description: list of open PR's
         type: string
@@ -42,21 +42,6 @@ jobs:
           repo: ${{ inputs.repo }}
           GH_TOKEN: ${{ secrets.PAT }}
 
-  init:
-    name: Initialize Workflow
-    needs: init-status
-    runs-on: ubuntu-latest
-    steps:
-      - name: Update Summary
-        run: |
-          echo "SHA : ${{ inputs.ref }}"
-          echo "## Yocto Build Generation" >> $GITHUB_STEP_SUMMARY
-          echo "- Pull Request Number: \`${{ inputs.pr || 'Nightly Build on Tip' }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "- Head Commit SHA: \`${{ inputs.sha || 'N/A' }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "- Target Branch: \`${{ inputs.ref || 'N/A' }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "- Target Repository: \`${{ inputs.repo || 'N/A' }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "- Base: \`${{ inputs.base || 'N/A' }}\`" >> $GITHUB_STEP_SUMMARY
-
   loading:
     name: Load Parameters
     needs: init-status
@@ -67,7 +52,7 @@ jobs:
 
   build_yocto:
     name: Build Yocto
-    needs: [init-status, init, loading]
+    needs: [init-status, loading]
     uses: qualcomm-linux/kernel-config/.github/workflows/build-yocto.yml@main
     secrets: inherit
     with:
@@ -80,7 +65,7 @@ jobs:
 
   check_run:
     runs-on: ubuntu-latest
-    needs: [init-status, init, loading, build_yocto]
+    needs: [init-status, loading, build_yocto]
     steps:
       - name: Post check run
         uses: qualcomm-linux/kernel-config/.github/actions/check_run@main
@@ -114,11 +99,12 @@ jobs:
   nightly_report:
     name: Nightly Test Report
     if: always()
-    needs: [test]
+    needs: [build_yocto, test]
     runs-on: ubuntu-latest
     steps:
       - name: Download all test JSON artifacts
         uses: actions/download-artifact@v4
+        continue-on-error: true
         with:
           pattern: Tests-*
           path: all-json
@@ -126,6 +112,7 @@ jobs:
 
       - name: Download all job info artifacts
         uses: actions/download-artifact@v4
+        continue-on-error: true
         with:
           pattern: job_info_*
           path: job-info
@@ -139,6 +126,11 @@ jobs:
           short_sha="${sha:0:7}"
           commit_url="https://github.com/${{ inputs.repo }}/commit/${sha}"
           run_url="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          s3_location="${{ needs.build_yocto.outputs.artifacts_location }}"
+          s3_path="N/A"
+          if [ -n "$s3_location" ]; then
+            s3_path="s3://qli-prd-kernel-gh-artifacts/${s3_location}/"
+          fi
 
           declare -A JOB_URLS=()
           job_info_re='^- \[([^[:space:]]+) Job [^]]+ on ([^]]+)\]\(([^)]*)\)'
@@ -155,20 +147,16 @@ jobs:
           fi
 
           {
-            echo "# Nightly LAVA Test Report"
+            echo "# Yocto Build and Test Report"
             echo ""
-            echo "| | |"
+            echo "## Build Artifacts"
+            echo ""
+            echo "| Field | Value |"
             echo "| --- | --- |"
-            echo "| **Branch** | \`${{ inputs.ref }}\` |"
-            echo "| **Commit** | [\`${short_sha}\`](${commit_url}) |"
-            echo "| **Run** | [${run_url}](${run_url}) |"
+            echo "| AWS S3 Path | \`${s3_path}\` |"
+            echo "| Commit | [\`${short_sha}\`](${commit_url}) |"
+            echo "| Run | [${run_url}](${run_url}) |"
             echo ""
-
-            if ls job-info/*.md 1>/dev/null 2>&1; then
-              echo "## LAVA Jobs"
-              cat job-info/*.md
-              echo ""
-            fi
 
             mapfile -t FILES < <(ls "$INPUT_DIR"/*.json 2>/dev/null || true)
             if [ ${#FILES[@]} -gt 0 ]; then
@@ -230,6 +218,11 @@ jobs:
                   printf "| %s | %s | %s | %s | %s |\n" "$t" "$pass" "$fail" "$skip" "$total"
                 fi
               done
+
+            else
+              echo "## Test Matrix"
+              echo ""
+              echo "No test result artifacts were found."
             fi
           } >> "$GITHUB_STEP_SUMMARY"
 

--- a/.github/workflows/pre-merge-yocto.yml
+++ b/.github/workflows/pre-merge-yocto.yml
@@ -46,19 +46,6 @@ jobs:
           repo: ${{ github.event.inputs.repo || github.repository }}
           GH_TOKEN: ${{ secrets.PAT }}
 
-  init:
-    name: Initialize Workflow
-    needs: init-status
-    runs-on: ubuntu-latest
-    steps:
-      - name: Update Summary
-        run: |
-          echo "## Yocto Build Generation" >> $GITHUB_STEP_SUMMARY
-          echo "- Pull Request Number: \`${{ github.event.inputs.pr || 'N/A' }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "- Head Commit SHA: \`${{ github.event.inputs.sha || 'N/A' }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "- Target Branch: \`${{ github.event.inputs.ref || 'N/A' }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "- Target Repository: \`${{ github.event.inputs.repo || 'N/A' }}\`" >> $GITHUB_STEP_SUMMARY
-
   loading:
     name: Load Parameters
     needs: init-status
@@ -67,7 +54,7 @@ jobs:
 
   build_yocto:
     name: Build Yocto
-    needs: [init-status, init, loading]
+    needs: [init-status, loading]
     uses: qualcomm-linux/kernel-config/.github/workflows/build-yocto.yml@main
     secrets: inherit
     with:
@@ -80,7 +67,7 @@ jobs:
 
   check_run:
     runs-on: ubuntu-latest
-    needs: [init-status, init, loading, build_yocto]
+    needs: [init-status, loading, build_yocto]
     steps:
       - name: Post check run
         uses: qualcomm-linux/kernel-config/.github/actions/check_run@main
@@ -114,11 +101,12 @@ jobs:
   premerge_report:
     name: Pre-merge LAVA Test Report
     if: always()
-    needs: [test]
+    needs: [build_yocto, test]
     runs-on: ubuntu-latest
     steps:
       - name: Download all test JSON artifacts
         uses: actions/download-artifact@v4
+        continue-on-error: true
         with:
           pattern: Tests-*
           path: all-json
@@ -126,6 +114,7 @@ jobs:
 
       - name: Download all job info artifacts
         uses: actions/download-artifact@v4
+        continue-on-error: true
         with:
           pattern: job_info_*
           path: job-info
@@ -138,8 +127,12 @@ jobs:
           sha="${{ inputs.sha }}"
           short_sha="${sha:0:7}"
           commit_url="https://github.com/${{ inputs.repo }}/commit/${sha}"
-          pr_url="https://github.com/${{ inputs.repo }}/pull/${{ inputs.pr }}"
           run_url="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          s3_location="${{ needs.build_yocto.outputs.artifacts_location }}"
+          s3_path="N/A"
+          if [ -n "$s3_location" ]; then
+            s3_path="s3://qli-prd-kernel-gh-artifacts/${s3_location}/"
+          fi
 
           declare -A JOB_URLS=()
           job_info_re='^- \[([^[:space:]]+) Job [^]]+ on ([^]]+)\]\(([^)]*)\)'
@@ -156,21 +149,16 @@ jobs:
           fi
 
           {
-            echo "# Pre-merge LAVA Test Report"
+            echo "# Yocto Build and Test Report"
             echo ""
-            echo "| | |"
+            echo "## Build Artifacts"
+            echo ""
+            echo "| Field | Value |"
             echo "| --- | --- |"
-            echo "| **Pull Request** | [#${{ inputs.pr }}](${pr_url}) |"
-            echo "| **Branch** | \`${{ inputs.ref }}\` |"
-            echo "| **Commit** | [\`${short_sha}\`](${commit_url}) |"
-            echo "| **Run** | [${run_url}](${run_url}) |"
+            echo "| AWS S3 Path | \`${s3_path}\` |"
+            echo "| Commit | [\`${short_sha}\`](${commit_url}) |"
+            echo "| Run | [${run_url}](${run_url}) |"
             echo ""
-
-            if ls job-info/*.md 1>/dev/null 2>&1; then
-              echo "## LAVA Jobs"
-              cat job-info/*.md
-              echo ""
-            fi
 
             mapfile -t FILES < <(ls "$INPUT_DIR"/*.json 2>/dev/null || true)
             if [ ${#FILES[@]} -gt 0 ]; then
@@ -232,6 +220,11 @@ jobs:
                   printf "| %s | %s | %s | %s | %s |\n" "$t" "$pass" "$fail" "$skip" "$total"
                 fi
               done
+
+            else
+              echo "## Test Matrix"
+              echo ""
+              echo "No test result artifacts were found."
             fi
           } >> "$GITHUB_STEP_SUMMARY"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -254,13 +254,6 @@ jobs:
             job_url="${{ steps.submit_job.outputs.job_url }}"
             job_id="${{ steps.submit_job.outputs.job_id }}"
           fi
-          SUMMARY='
-          <details><summary><i>'${status}'</i></summary>
-          <br>
-          JOB ID: <a href="${job_url}">'${job_id}'</a>
-          </details>
-          '
-          echo -e "$SUMMARY" >> $GITHUB_STEP_SUMMARY
           JOB_INFO="- [${{ inputs.image_type }} Job $job_id on ${{ matrix.rootfs_matrix.machine }}]($job_url)"
           echo -e "$JOB_INFO" > job_info.md
 


### PR DESCRIPTION
Reduce duplicate GitHub step summary output from Yocto build and LAVA test jobs. Keep a single Yocto build and test report with the AWS S3 artifact path, linked test matrix, and testcase summary totals.