### PR TITLE
ci: Do not fail test job on LAVA testcase failures

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -189,18 +189,10 @@ jobs:
           done
           echo "Job health: $HEALTH"
           if [[ "$HEALTH" == "Complete" ]]; then
-            TEST_RESULTS=$(docker run -i --rm --workdir="$PWD" -v "$(dirname $PWD)":"$(dirname $PWD)" ${{ inputs.docker_image }} sh -c "lavacli identities add --token ${{ secrets.LAVA_OSS_TOKEN }} --uri https://lava-oss.qualcomm.com/RPC2 --username ${{ secrets.LAVA_OSS_USER }} production && lavacli -i production results $JOB_ID" | grep fail || echo "Pass")
-            if [[ "$TEST_RESULTS" == "Pass" ]]; then
-               echo "Lava job passed."
-               summary=":heavy_check_mark: Lava job passed."
-               echo "summary=$summary" >> $GITHUB_OUTPUT
-               exit 0
-            else
-               echo "Lava job failed."
-               summary=":x: Lava job failed."
-               echo "summary=$summary" >> $GITHUB_OUTPUT
-               exit 1
-            fi
+            echo "Lava job completed."
+            summary=":heavy_check_mark: Lava job completed."
+            echo "summary=$summary" >> $GITHUB_OUTPUT
+            exit 0
           else
             echo "Lava job failed."
             summary=":x: Lava job failed."


### PR DESCRIPTION
Treat a completed LAVA job as successful for workflow status even when individual testcases fail. Testcase results are still collected into JSON artifacts for the Yocto report matrix and summary.