### PR TITLE
qcom-next.conf: add lyra topic branch

### DIFF
--- a/qcom-next.conf
+++ b/qcom-next.conf
@@ -72,3 +72,4 @@ tech/noup/debug/all        https://github.com/qualcomm-linux/kernel-topics.git  
 tech/hwe/unoq              https://github.com/qualcomm-linux/kernel-topics.git       tech/hwe/unoq
 early/hwe/shikra/drivers   https://github.com/qualcomm-linux/kernel-topics.git       early/hwe/shikra/drivers
 early/hwe/shikra/dt        https://github.com/qualcomm-linux/kernel-topics.git       early/hwe/shikra/dt
+early/hwe/lyra             https://github.com/qualcomm-linux/kernel-topics.git       early/hwe/lyra


### PR DESCRIPTION
Add lyra topic branch to qcom-next.conf.